### PR TITLE
Add support for Monotonic Versioning

### DIFF
--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicChange.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicChange.md
@@ -1,0 +1,24 @@
+# `MonotonicChange` enumeration
+
+```c#
+[CLSCompliant(true)]
+public enum MonotonicChange
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ./
+
+The types of change which may be made to a monotonic-versioned
+software package.
+
+### Members
+
+- **`Compatible`**  
+  A backwards-compatible change, where the change would not break
+  existing uses of the software package's API.
+
+- **`Breaking`**  
+  A breaking change, where the change will break existing uses of
+  the software package's API.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicComparer/Compare(SemanticVersion,SemanticVersion).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicComparer/Compare(SemanticVersion,SemanticVersion).md
@@ -1,0 +1,45 @@
+# `MonotonicComparer.Compare(SemanticVersion, SemanticVersion)` method
+
+```c#
+public int Compare(
+    SemanticVersion x,
+    SemanticVersion y
+)
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0  
+**Implements:** `System.Collections.Generic.IComparer<SemanticVersion>.Compare`
+
+[1]: ../
+
+Compares two monotonic versions and returns an indication of
+their relative order.
+
+### Parameters
+
+- **`x`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+  The monotonic version to compare to _`y`_.
+- **`y`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+  The monotonic version to compare to _`x`_.
+
+[2]: ../../SemanticVersion
+
+### Return Value
+
+**Type:** `System.Int32`
+
+A value less than zero if _`x`_ precedes _`y`_ in sort order, or if
+_`x`_ is null and _`y`_ is not null.
+
+Zero if _`x`_ is equal to _`y`_, including if both are null.
+
+A value greater than zero if _`x`_ follows _`y`_ in sort order, or if
+_`y`_ is null and _`x`_ is not null.
+
+## Exceptions
+
+- **`System.ArgumentException`**  
+  _`x`_ or _`y`_ is not a valid monotonic version.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicComparer/README.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicComparer/README.md
@@ -1,0 +1,39 @@
+# `MonotonicComparer` class
+
+```c#
+[CLSCompliant(true)]
+public sealed class MonotonicComparer : IComparer<SemanticVersion>
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+Represents a semantic version comparison operation using monotonic
+versioning comparison rules.
+
+[1]: ../
+
+
+### Constructors
+
+None public.
+
+### Methods
+
+- **[Compare(SemanticVersion, SemanticVersion)][2]**  
+  Compares two monotonic versions and returns an indication of
+  their relative order.
+  
+### Static Properties
+
+- **[Standard][3]**  
+  A `MonotonicComparer` which compares using the standard rules
+  for monotonic versions.
+
+[2]: ./Compare(SemanticVersion,SemanticVersion).md
+[3]: ./Standard.md
+
+## Remarks
+
+This class compares monotonic versions as set out by the Monotonic
+Versioning Manifesto 1.2.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicComparer/Standard.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicComparer/Standard.md
@@ -1,0 +1,16 @@
+# `MonotonicComparer.Standard` property
+
+```c#
+public static MonotonicComparer Standard { get; }
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum version:** 1.2.0
+
+[1]: ../../
+
+**Type:** [`McSherry.SemanticVersioning.Monotonic.MonotonicComparer`][2]  
+A [MonotonicComparer][2] which compares using the standard rules
+for monotonic versions.
+
+[2]: ../

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicExtensions/IsMonotonic(SemanticVersion).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicExtensions/IsMonotonic(SemanticVersion).md
@@ -1,0 +1,40 @@
+# `MonotonicExtensions.IsMonotonic(SemanticVersion)`method
+
+```c#
+public static bool IsMonotonic(
+    this SemanticVersion version
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+Determines whether a [SemanticVersion][2] is a valid monotonic version.
+
+[1]: ../
+[2]: ../../SemanticVersion
+
+### Parameters
+
+- **`version`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+  The [SemanticVersion][2] to be checked.
+
+### Return Value
+
+**Type:** `System.Bool`
+
+True if _`version`_ is a valid monotonic version, false if otherwise.
+
+## Exceptions
+
+- **`System.ArgumentNullException`**  
+  _`version`_ is null.
+
+## Remarks
+
+A [SemanticVersion][2] is considered a valid version if it: has no
+[SemanticVersion.Patch][3] component; and has no [SemanticVersion.Identifiers][4].
+
+[3]: ../../SemanticVersion/Patch.md
+[4]: ../../SemanticVersion/Identifiers.md

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicExtensions/README.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicExtensions/README.md
@@ -1,0 +1,26 @@
+# `MonotonicExtensions` class
+
+```c#
+[CLSCompliant(true)]
+public static class MonotonicExtensions
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+Provides extension methods relating to treating [SemanticVersion][2]s as
+monotonic versions.
+
+[1]: ../
+[2]: ../../SemanticVersion
+
+## Methods
+
+- **[IsMonotonic(SemanticVersion)][3]**  
+  Determines whether a [SemanticVersion][2] is a valid monotonic version.
+
+[3]: ./IsMonotonic(SemanticVersion).md
+
+## Remarks
+
+The methods this class provides are based on the Monotonic Versioning Manifesto 1.2.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Chronology.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Chronology.md
@@ -1,0 +1,18 @@
+# `MonotonicVersioner.Chronology` property
+
+```c#
+public IEnumerable<SemanticVersion> Chronology { get; }
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+**Type:** `System.Collections.Generic.IEnumerable<SemanticVersion>`  
+The monotonic versions this instance has produced, in chronological order.
+
+## Remarks
+
+For monotonic versions, chronological order means the versions are ordered
+by ascending release number.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Clone().md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Clone().md
@@ -1,0 +1,20 @@
+# `MonotonicVersioner.Clone()` method
+
+```c#
+public MonotonicVersioner Clone()
+```
+
+**Namespace:** [`McSherry.SemanticVersioning.Monotonic`][1]  
+**Minimum version:** 1.2.0
+
+Returns a [MonotonicVersioner][2] with an identical chronology,
+but which can advance its versions separately.
+
+[1]: ../
+[2]: ./
+
+### Return Value
+
+A [MonotonicVersioner][2] with an identical chronology up to the
+moment this method was called, but which is able to separately
+advance its version numbers.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Compatibility.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Compatibility.md
@@ -1,0 +1,14 @@
+# `MonotonicVersioner.Compatibility` property
+
+```c#
+public int Compatibility { get; }
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+**Type:** `System.Int32`  
+The highest compatibility number. This component indicates which releases
+are compatible with each other.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Latest.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Latest.md
@@ -1,0 +1,19 @@
+# `MonotonicVersioner.Latest` property
+
+```c#
+public SemanticVersion Latest { get; }
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+**Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+The chronologically-latest verson number in this versioning sequence.
+
+[1]: ../
+[2]: ../../SemanticVersion
+
+## Remarks
+
+The chronologically-latest version is the version with the greatest value as
+its release component, regardless of the line of compatibility.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/LatestVersions.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/LatestVersions.md
@@ -1,0 +1,14 @@
+# `MonotonicVersioner.LatestVersions` property
+
+```c#
+public IReadOnlyDictionary<int, SemanticVersion> LatestVersions { get; }
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+**Type:** `System.Collections.Generic.IReadOnlyDictionary<int, SemanticVersion>`  
+The latest versions in each line of compatibility, where the key is the line
+of compatibility.
+
+[1]: ../

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(Int32,MonotonicChange).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(Int32,MonotonicChange).md
@@ -1,0 +1,49 @@
+# `MonotonicVersioner.Next(Int32, MonotonicChange)` method
+
+```c#
+public SemanticVersion Next(
+    int line,
+    MonotonicChange change
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Returns the next version number when a specified change is made to a given
+line of compatibility.
+
+### Parameters
+
+- **`line`**  
+  **Type:** `System.Int32`  
+  The line of compatibility to which the change is being made.
+- **`change`**  
+  **Type:** [`McSherry.SemanticVersioning.Monotonic.MonotonicChange`][2]  
+  The type of change being made to _`line`_.
+
+[2]: ../MonotonicChange.md
+
+### Return Value
+
+**Type:** [`McSherry.SemanticVersioning.SemanticVersion`][3]
+
+The next version number produced when the specified change is made to the
+specified line of compatibility.
+
+If _`change`_ is equal to [`MonotonicChange.Compatible`][2], the release
+number is incremented but the compatibility number remains the same.
+
+If _`change`_ is equal to [`MonotonicChange.Breaking`][2], both the release
+and compatibility numbers are incremented.
+
+## Exceptions
+
+- **`System.ArgumentOutOfRangeException`**  
+  _`line`_ is negative.  
+  _`change`_ is not a recognised type of change.
+  
+- **`System.ArgumentException`**  
+  _`line`_ is not a current line of compatibility.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(Int32,MonotonicChange,IEnumerable(String)).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(Int32,MonotonicChange,IEnumerable(String)).md
@@ -1,0 +1,57 @@
+# `MonotonicVersioner.Next(Int32, MonotonicChange, IEnumerable<String>)` method
+
+```c#
+public SemanticVersion Next(
+    int line,
+    MonotonicChange change,
+    IEnumerable<string> metadata
+    )
+```</string>
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Returns the next version number when a specified change is made to a given
+line of compatibility with the specified metadata.
+
+### Parameters
+
+- **`line`**  
+  **Type:** `System.Int32`  
+  The line of compatibility to which the change is being made.
+- **`change`**  
+  **Type:** [`McSherry.SemanticVersioning.Monotonic.MonotonicChange`][2]  
+  The type of change being made to _`line`_.
+- **`metadata`**  
+  **Type:** `System.Collections.Generic.IEnumerable<string>`  
+  The metadata to be included with the new version.
+
+[2]: ../MonotonicChange.md
+
+### Return Value
+
+**Type:** [`McSherry.SemanticVersioning.SemanticVersion`][3]
+
+The next version number produced when the specified change is made to the
+specified line of compatibility.
+
+If _`change`_ is equal to [`MonotonicChange.Compatible`][2], the release
+number is incremented but the compatibility number remains the same.
+
+If _`change`_ is equal to [`MonotonicChange.Breaking`][2], both the release
+and compatibility numbers are incremented.
+
+## Exceptions
+
+- **`System.ArgumentOutOfRangeException`**  
+  _`line`_ is negative.  
+  _`change`_ is not a recognised type of change.
+
+- **`System.ArgumentNullException`**  
+  _`metadata`_ or an item therein is null.
+  
+- **`System.ArgumentException`**  
+  One or more items within _`metadata`_ is not a valid metadata string.  
+  _`line`_ is not a current line of compatibility.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(MonotonicChange).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(MonotonicChange).md
@@ -1,0 +1,43 @@
+# `MonotonicVersioner.Next(MonotonicChange)` method
+
+```c#
+public SemanticVersion Next(
+    MonotonicChange change
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Returns the next version number when a specified change is made to
+the latest version.
+
+### Parameters
+
+- **`change`**  
+  **Type:** [`McSherry.SemanticVersioning.Monotonic.MonotonicChange`][2]  
+  The type of change being made to the latest version.
+
+[2]: ../MonotonicChange.md
+
+### Return Value
+
+**Type:** [`McSherry.SemanticVersioning.SemanticVersion`][3]
+
+The next version number produced when the specified change is made to the
+latest version.
+
+If _`change`_ is equal to [`MonotonicChange.Compatible`][2], the release
+number is incremented by the compatibility number remains the same.
+
+If _`change`_ is equal to [`MonotonicChange.Breaking`][2], both the release
+and compatibility numbers are incremented.
+
+[3]: ../../SemanticVersion
+
+## Exceptions
+
+- **`System.ArgumentOutOfRangeException`**  
+  _`change`_ is not a recognised type of change.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(MonotonicChange,IEnumerable(String)).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Next(MonotonicChange,IEnumerable(String)).md
@@ -1,0 +1,48 @@
+# `MonotonicVersioner.Next(MonotonicChange, IEnumerable<string>)` method
+
+```c#
+public SemanticVersion Next(
+    MonotonicChange change,
+    IEnumerable<string> metadata
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Returns the next version number when a specified change is made to the
+latest version.
+
+### Parameters
+
+- **`change`**  
+  **Type:** [`McSherry.SemanticVersioning.Monotonic.MonotonicChange`][2]  
+  The type of change being made to the latest version.
+  
+- **`metadata`**  
+  **Type:** `System.Collections.Generic.IEnumerable<string>`  
+  The metadata to be included with the new version.
+
+[2]: ../MonotonicChange.md
+
+### Return Value
+
+The next version number produced when the specified change is made to the
+latest version, with the specified metadata.
+
+If _`change`_ is equal to [`MonotonicChange.Compatible`][2], the release
+number is incremented by the compatibility number remains the same.
+
+If _`change`_ is equal to [`MonotonicChange.Breaking`][2], both the release
+and compatibility numbers are incremented.
+
+## Exceptions
+
+- **`System.ArgumentOutOfRangeException`**  
+  _`change`_ is not a recognised type of change.
+- **`System.ArgumentNullException`**  
+  _`metadata`_ or an item therein is null.
+- **`System.ArgumentException`**  
+  One or more items within _`metadata`_ is not a valid metadata string.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/README.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/README.md
@@ -1,0 +1,98 @@
+# `MonotonicVersioner` class
+
+```c#
+[CLSCompliant(true)]
+public sealed class MonotonicVersioner
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+Provides a method of working with [SemanticVersion][2]s as monotonic versions.
+
+[1]: ../
+[2]: ../../SemanticVersion
+
+## Constructors
+
+- **[MonotonicVersioner()][3]**  
+  Creates a new [MonotonicVersioner][4] instance.
+
+- **[MonotonicVersioner(bool)][5]**  
+  Creates a new [MonotonicVersioner][4] instance with the specified initial
+  compatibility line.
+
+- **[MonotonicVersioner(bool, IEnumerable(String))][6]**  
+  Creates a new [MonotonicVersioner][4] instance with the specified initial
+  compatibility line and metadata.
+
+- **[MonotonicVersioner(IEnumerable(SemanticVersion))][7]**  
+  Creates a new [MonotonicVersioner][4] with the specified version number
+  history.
+
+[3]: ./ctor().md
+[4]: ./
+[5]: ./ctor(bool).md
+[6]: ./ctor(bool,IEnumerable(String)).md
+[7]: ./ctor(IEnumerable(SemanticVersion)).md
+
+## Properties
+
+- **[Latest][8]**  
+  The chronologically-latest version number in this versioning sequence.
+- **[LatestVersions][9]**  
+  The latest versions in each line of compatibility, where the key is the
+  line of compatibility.
+- **[Compatibility][10]**  
+  The highest compatibility number. This component indicates which releases
+  are compatible with each other.
+- **[Release][11]**  
+  The current release number. This component indicates when a release was
+  made relative to other releases.
+- **[Chronology][12]**  
+  The monotonic versions this instance has produced, in chronological order.
+
+[8]:  ./Latest.md
+[9]:  ./LatestVersions.md
+[10]: ./Compatibility.md
+[11]: ./Release.md
+[12]: ./Chronology.md
+
+## Methods
+
+- **[Next(MonotonicChange)][13]**  
+  Returns the next version number when a specified change is made to the latest
+  version.
+- **[Next(MonotonicChange, IEnumerable(String))][14]**  
+  Returns the next version number when a specified change is made to the latest
+  version.
+- **[Next(Int32, MonotonicChange)][15]**  
+  Returns the next version number when a specified change is made to a given line
+  of compatibility.
+- **[Next(Int32, MonotonicChange, IEnumerable(String))][16]**  
+  Returns the next version number when a specified change is made to a given line
+  of compatibility.
+- **[Clone()][17]**  
+  Returns a [MonotonicVersioner][1] with an identical chronology, but which can
+  advcance its versions separately.
+
+[13]: ./Next(MonotonicChange).md
+[14]: ./Next(MonotonicChange,IEnumerable(String)).md
+[15]: ./Next(Int32,MonotonicChange).md
+[16]: ./Next(Int32,MonotonicChange,IEnumerable(String)).md
+[17]: ./Clone().md
+
+## Remarks
+
+Monotonic Versioning is a simplified versioning scheme that is compatible with
+Semantic Versioning 2.0.0. The scheme uses two components: compatibility, indicating
+a "line of compatibility" where all versions with the same component are compatible;
+and release, which is incremented with every release, regardless of the line of
+compatibility.
+
+For example, a first release would be "1.0". A backwards-compatible update to this
+would be "1.1". If a breaking change was made, that release would be "2.2". However,
+if the first line of compatibility was updated again, it would be "1.3".
+
+The full manifesto is available from the Applied Computer Science Lab website. This
+class is based on the 1.2 manifesto.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Release.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/Release.md
@@ -1,0 +1,14 @@
+# `MonotonicVersioner.Release` property
+
+```c#
+public int Release { get; }
+```
+
+**Namespace:** [McSherry.SemanticVersion.Montonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+**Type:** `System.Int32`  
+The current release number. This component indicates when a release was
+made relative to other releases.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor().md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor().md
@@ -1,0 +1,22 @@
+# `MonotonicVersioner` constructor
+
+```c#
+public MonotonicVersioner()
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+Creates a new [`MonotonicVersioner`][2] instance.
+
+[1]: ../
+[2]: ./
+
+## Remarks
+
+The [`Compatibility`][3] number sequence produced by an instance which
+was created using this constructor starts at one. If a zero-based
+sequence is required, use [`MonotonicVersioner(bool)`][4].
+
+[3]: ./Compatibility.md
+[4]: ./ctor(bool).md

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor(IEnumerable(SemanticVersion)).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor(IEnumerable(SemanticVersion)).md
@@ -1,0 +1,39 @@
+# `MonotonicVersioner` constructor
+
+```c#
+public MonotonicVersioner(
+    IEnumerable<SemanticVersion> chronology
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Creates a new [`MonotonicVersioner`][2] with the specified
+version number history.
+
+### Parameters
+
+- **`chronology`**  
+  **Type:** `System.Collections.Generic.IEnumerable<SemanticVersion>`  
+  A collection of version numbers providing the version history to
+  use for this instance.
+
+## Exceptions
+
+- **`System.ArgumentNullException`**  
+  _`chronology`_ or an item thereof is null.
+
+- **`System.ArgumentOutOfRangeException`**  
+  _`chronology`_ contains a version which is not a
+  valid monotonic version.
+
+- **`System.ArgumentException`**  
+  _`chronology`_ provides an incomplete version history.
+  The chronology may:  
+    - Not provide a contiguous sequence of [`Compatibility`][3] numbers;
+    - Not provide a contiguous sequence of [`Release`][4] numbers;
+    - Not contain a [`Compatibility`][3] starting at either zero or one;
+    - Be empty.

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor(bool).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor(bool).md
@@ -1,0 +1,38 @@
+# `MonotonicVersioner` constructor
+
+```c#
+public MonotonicVersioner(
+    bool startAtOne
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Creates a new [`MonotonicVersioner`][2] instance with the specified
+initial compatibility line.
+
+[2]: ./
+
+### Parameters
+
+- **`startAtOne`**  
+  **Type:** `System.Bool`  
+  If true, the produced [`Compatibility`][3] number sequence starts
+  at one. If false, zero.
+
+[3]: ./Compatibility.md
+
+## Remarks
+
+The Monotonic Versioning Manifesto 1.2 does not specify whether the
+[`Compatiblity`][3] component of versions are to start at one or zero.
+It is assumed that either is valid as neither is specifically
+recommended nor prohibited.
+
+If the [`Compatibility`][3] components are to start at one,
+[`MonotonicVersioner()`][4] may be used.
+
+[4]: ./ctor().md

--- a/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor(bool,IEnumerable(String)).md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/MonotonicVersioner/ctor(bool,IEnumerable(String)).md
@@ -1,0 +1,43 @@
+# `MonotonicVersioner` constructor
+
+```c#
+public MonotonicVersioner(
+    bool startAtOne,
+    IEnumerable<string> metadata
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Monotonic][1]  
+**Minimum Version:** 1.2.0
+
+[1]: ../
+
+Creates a new [`MonotonicVersioner`][2] instance with the
+specified initial compatibility line and metadata.
+
+### Parameters
+
+- **`startAtOne`**  
+  **Type:** `System.Bool`  
+  If true, the produced [`Compatibility`][3] number sequence
+  starts at one. If false, zero.
+- **`metadata`**  
+  **Type:** `System.Collections.Generic.IEnumerable<string>`  
+  Any metadata items to be included as part of the initial
+  version number.
+
+## Exceptions
+
+- **`System.ArgumentNullException`**  
+  _`metadata`_ or any item thereof is null.
+
+- **`System.ArgumentException`**  
+  One or more of the items in _`metadata`_ is not a valid
+  metadata item.
+
+## Remarks
+
+The Monotonic Versioning Manifesto 1.2 does not specify whether the
+[`Compatiblity`][3] component of versions are to start at one or zero.
+It is assumed that either is valid as neither is specifically
+recommended nor prohibited.

--- a/docs/McSherry.SemanticVersioning/Monotonic/README.md
+++ b/docs/McSherry.SemanticVersioning/Monotonic/README.md
@@ -1,0 +1,33 @@
+# `McSherry.SemanticVersioning.Monotonic` namespace
+
+The `McSherry.SemanticVersioning.Monotonic` namespace provides classes which aid in the
+support of [Monotonic Versioning v1.2][1]. Any valid Monotonic Version can be parsed
+with a Semantic Version parser, and thus this namespace works with instances of the
+[`SemanticVersion`][2] class.
+
+[1]: http://web.archive.org/web/20160523103913/http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/
+[2]: ../SemanticVersion
+
+## Classes
+
+- **[MonotonicComparer][3]**  
+  Represents a semantic version comparison operation using monotonic
+  versioning comparison rules.
+- **[MonotonicExtensions][4]**  
+  Provides extension methods related to treating [SemanticVersion][2]s
+  as monotonic versions.
+- **[MonotonicVersioner][5]**  
+  Provides a method of working with [SemanticVersion][2]s as monotonic
+  versions.
+
+[3]: ./MonotonicComparer
+[4]: ./MonotonicExtensions
+[5]: ./MonotonicVersioner
+
+## Enumerations
+
+- **[MonotonicChange][6]**  
+  The types of change which may be made to a monotonic-versioned
+  software package.
+
+[6]: ./MonotonicChange.md

--- a/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
@@ -183,6 +183,42 @@ namespace McSherry.SemanticVersioning.Monotonic
             Assert.AreEqual(Ordering.Lesser, cmp(m4, m5));
             Assert.AreEqual(Ordering.Greater, cmp(m5, m4));
         }
+        /// <summary>
+        /// <para>
+        /// Tests that capital letters in metadata are sorted before
+        /// lowercase letters.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Casing()
+        {
+            // Lexical sort is what we're told. Since the valid characters
+            // are a restricted subset of ASCII, and since we have nothing
+            // else to go on, we're going to assume that we should sort
+            // capital letters before lowercase letters (since the ASCII
+            // encodings for capital letters have smaller values than those
+            // for lowercase letters).
+            //
+            // Since we have to give later-sorted elements precedence, this
+            // means that lowercased metadata items should take precedence.
+            //
+            // Where metadata items have the same case, alphabetic sorting
+            // should still apply.
+            var v0 = (SemanticVersion)"1.0+ABC";
+            var v1 = (SemanticVersion)"1.0+abc";
+            var v2 = (SemanticVersion)"1.0+DEF";
+            var v3 = (SemanticVersion)"1.0+def";
+
+            Assert.AreEqual(Ordering.Lesser, cmp(v0, v1));
+            Assert.AreEqual(Ordering.Lesser, cmp(v2, v1));
+            Assert.AreEqual(Ordering.Lesser, cmp(v0, v2));
+            Assert.AreEqual(Ordering.Lesser, cmp(v2, v3));
+
+            Assert.AreEqual(Ordering.Greater, cmp(v1, v0));
+            Assert.AreEqual(Ordering.Greater, cmp(v1, v2));
+            Assert.AreEqual(Ordering.Greater, cmp(v2, v0));
+            Assert.AreEqual(Ordering.Greater, cmp(v3, v2));
+        }
 
         /// <summary>
         /// <para>

--- a/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
@@ -74,20 +74,18 @@ namespace McSherry.SemanticVersioning.Monotonic
         [TestMethod, TestCategory(Category)]
         public void General_DifferentCompatibilities()
         {
-            // Each of these should be higher precedence than the last.
             var m0 = new SemanticVersion(1, 0);
             var m1 = new SemanticVersion(2, 1);
             var m2 = new SemanticVersion(1, 2);
 
+            // Greater compatibility component takes precedence.
             Assert.AreEqual(Ordering.Lesser, cmp(m0, m1));
-            Assert.AreEqual(Ordering.Lesser, cmp(m1, m2));
-
-            Assert.AreEqual(Ordering.Lesser, cmp(m0, m2));
-
-
-            Assert.AreEqual(Ordering.Greater, cmp(m2, m1));
+            Assert.AreEqual(Ordering.Greater, cmp(m1, m2));
             Assert.AreEqual(Ordering.Greater, cmp(m1, m0));
+            Assert.AreEqual(Ordering.Lesser, cmp(m2, m1));
 
+            // Compatibility the same, greater release takes precedence
+            Assert.AreEqual(Ordering.Lesser, cmp(m0, m2));
             Assert.AreEqual(Ordering.Greater, cmp(m2, m0));
         }
         /// <summary>

--- a/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
@@ -154,14 +154,26 @@ namespace McSherry.SemanticVersioning.Monotonic
             // the latter's compatibility component gives it overall greater
             // precedence.
 
-            var m0 = new SemanticVersion(2, 5, 0, new[] { "abc", "def", "ghi" });
-            var m1 = new SemanticVersion(2, 5, 0, new[] { "abc", "def", "jkl" });
+            var m0 = new SemanticVersion(
+                2, 5, 0, Enumerable.Empty<string>(), new[] { "abc", "def", "ghi" }
+                );
+            var m1 = new SemanticVersion(
+                2, 5, 0, Enumerable.Empty<string>(), new[] { "abc", "def", "jkl" }
+                );
 
-            var m2 = new SemanticVersion(1, 7, 0, new[] { "abc", "73" });
-            var m3 = new SemanticVersion(1, 7, 0, new[] { "abc", "2195" });
+            var m2 = new SemanticVersion(
+                1, 7, 0, Enumerable.Empty<string>(), new[] { "abc", "73" }
+                );
+            var m3 = new SemanticVersion(
+                1, 7, 0, Enumerable.Empty<string>(), new[] { "abc", "2195" }
+                );
 
-            var m4 = new SemanticVersion(1, 5, 0, new[] { "xyz" });
-            var m5 = new SemanticVersion(2, 5, 0, new[] { "abc" });
+            var m4 = new SemanticVersion(
+                1, 5, 0, Enumerable.Empty<string>(), new[] { "xyz" }
+                );
+            var m5 = new SemanticVersion(
+                2, 5, 0, Enumerable.Empty<string>(), new[] { "abc" }
+                );
 
 
             Assert.AreEqual(Ordering.Lesser, cmp(m0, m1));

--- a/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicComparerTests.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) 2015-16 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace McSherry.SemanticVersioning.Monotonic
+{
+    /// <summary>
+    /// <para>
+    /// Tests to ensure that <see cref="MonotonicComparer"/> produces the
+    /// results we expect when comparing <see cref="SemanticVersion"/>s.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public sealed class MonotonicComparerTests
+    {
+        private const string Category = "Monotonic Versioning - Comparer";
+
+        private Ordering cmp(SemanticVersion x, SemanticVersion y)
+            => MonotonicComparer.Standard.UseToCompare(x, y);
+
+        // 0 > x -> (x > y || (x == null && y != null))
+        // 0 = x -> (x == y)
+        // 0 < x -> (y > x || (x != null && y == null))
+
+        /// <summary>
+        /// <para>
+        /// Tests that basic monotonic versions produce the comparison
+        /// results expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Basic()
+        {
+            var m0 = new SemanticVersion(1, 0);
+            var m1 = new SemanticVersion(1, 1);
+
+            Assert.AreEqual(Ordering.Lesser, cmp(m0, m1));
+
+            Assert.AreEqual(Ordering.Greater, cmp(m1, m0));
+
+            Assert.AreEqual(Ordering.Equal, cmp(m0, m0));
+
+            Assert.AreEqual(Ordering.Equal, cmp(m1, m1));
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the correct precedence is reported even when
+        /// the comparands have a different compatibility component.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_DifferentCompatibilities()
+        {
+            // Each of these should be higher precedence than the last.
+            var m0 = new SemanticVersion(1, 0);
+            var m1 = new SemanticVersion(2, 1);
+            var m2 = new SemanticVersion(1, 2);
+
+            Assert.AreEqual(Ordering.Lesser, cmp(m0, m1));
+            Assert.AreEqual(Ordering.Lesser, cmp(m1, m2));
+
+            Assert.AreEqual(Ordering.Lesser, cmp(m0, m2));
+
+
+            Assert.AreEqual(Ordering.Greater, cmp(m2, m1));
+            Assert.AreEqual(Ordering.Greater, cmp(m1, m0));
+
+            Assert.AreEqual(Ordering.Greater, cmp(m2, m0));
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that null values receive the correct precedence
+        /// (i.e. that they are top-precedence).
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Nulls()
+        {
+            var m0 = new SemanticVersion(1, 0);
+            var m1 = new SemanticVersion(1000, 1000);
+            var m2 = (SemanticVersion)null;
+
+            Assert.AreEqual(Ordering.Greater, cmp(m2, m0));
+            Assert.AreEqual(Ordering.Greater, cmp(m2, m1));
+
+            Assert.AreEqual(Ordering.Lesser, cmp(m0, m2));
+            Assert.AreEqual(Ordering.Lesser, cmp(m1, m2));
+
+            Assert.AreEqual(Ordering.Equal, cmp(m2, m2));
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that versions with metadata are given correct precedence.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Metadata()
+        {
+            // Precedence with metadata is determined through lexically
+            // sorting the first metadata items which differ, where the
+            // "later" item has precedence.
+            //
+            // For example, given:
+            //      2.5+abc.def.ghi
+            //      2.5+abc.def.jkl
+            //
+            // Precedence would be determined by lexically sorting 'ghi'
+            // and 'jkl'. In this case, 'jkl' comes after 'ghi', so
+            // the second version string would have precedence.
+            //
+            // Like semantic versions, metadata items are constrained to
+            // ASCII alphanumerics plus a hyphen, so it's fairly easy to
+            // sort them.
+            //
+            // Notably, purely numeric metadata items are still sorted
+            // lexically, so given:
+            //      1.7+abc.73
+            //      1.7+abc.2195
+            //
+            // Lexically, '2' comes before '7', so the former version
+            // would have precedence even though '2195' would numerically
+            // sort after '73'.
+            //
+            // However, the metadata is irrelevant if the compatibility
+            // or release components would otherwise make one version of
+            // greater precedence than another. So, given:
+            //      1.5+xyz
+            //      2.5+abc
+            //
+            // Even though the former's metadata would have higher precedence,
+            // the latter's compatibility component gives it overall greater
+            // precedence.
+
+            var m0 = new SemanticVersion(2, 5, 0, new[] { "abc", "def", "ghi" });
+            var m1 = new SemanticVersion(2, 5, 0, new[] { "abc", "def", "jkl" });
+
+            var m2 = new SemanticVersion(1, 7, 0, new[] { "abc", "73" });
+            var m3 = new SemanticVersion(1, 7, 0, new[] { "abc", "2195" });
+
+            var m4 = new SemanticVersion(1, 5, 0, new[] { "xyz" });
+            var m5 = new SemanticVersion(2, 5, 0, new[] { "abc" });
+
+
+            Assert.AreEqual(Ordering.Lesser, cmp(m0, m1));
+            Assert.AreEqual(Ordering.Greater, cmp(m1, m0));
+
+            Assert.AreEqual(Ordering.Greater, cmp(m2, m3));
+            Assert.AreEqual(Ordering.Lesser, cmp(m3, m2));
+
+            Assert.AreEqual(Ordering.Lesser, cmp(m4, m5));
+            Assert.AreEqual(Ordering.Greater, cmp(m5, m4));
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests that <see cref="MonotonicComparer"/> will refuse to
+        /// compare versions that are not monotonic.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Invalid_NotMonotonic()
+        {
+            var m0 = new SemanticVersion(1, 6); // Is monotonic
+            var m1 = new SemanticVersion(1, 7, 1); // Isn't monotonic
+
+            new Action(() => cmp(m0, m1)).AssertThrows<ArgumentException>();
+            new Action(() => cmp(m1, m0)).AssertThrows<ArgumentException>();
+            new Action(() => cmp(m1, m1)).AssertThrows<ArgumentException>();
+        }
+    }
+}

--- a/libSemVer.NET.Testing/Monotonic/MonotonicExtensionsTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicExtensionsTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) 2015-16 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace McSherry.SemanticVersioning.Monotonic
+{
+    /// <summary>
+    /// <para>
+    /// Provides tests for each of the methods provided by
+    /// <see cref="MonotonicExtensions"/>.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public sealed class MonotonicExtensionsTests
+    {
+        private const string Category = "Monotonic Versioning - Extensions";
+
+        /// <summary>
+        /// <para>
+        /// Tests whether the method
+        /// <see cref="MonotonicExtensions.IsMonotonic(SemanticVersion)"/>
+        /// will produce the expected result for correct cases.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void IsMonotonic_Valid()
+        {
+            // A semantic version is a valid monotonic version if it:
+            //      a) Has a patch component of zero; and
+            //      b) Has no pre-release identifiers.
+            //
+            // If either of these conditions is not fulfilled, a semantic
+            // version is not a valid monotonic version.
+
+            var m0 = new SemanticVersion(1, 2);
+            var m1 = new SemanticVersion(1, 0, 0, new string[0], new[] { "x" });
+
+            Assert.IsTrue(m0.IsMonotonic());
+            Assert.IsTrue(m1.IsMonotonic());
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method
+        /// <see cref="MonotonicExtensions.IsMonotonic(SemanticVersion)"/>
+        /// rejects semantic versions which are not monotonic versions.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void IsMonotonic_Invalid()
+        {
+            // Has a non-zero patch component
+            var m0 = new SemanticVersion(2, 5, 1);
+            // Has pre-release identifier components
+            var m1 = new SemanticVersion(1, 0, 0, new[] { "abc" });
+            // Is null.
+            var m2 = (SemanticVersion)null;
+
+            Assert.IsFalse(m0.IsMonotonic());
+            Assert.IsFalse(m1.IsMonotonic());
+
+            new Action(() => m2.IsMonotonic())
+                .AssertThrows<ArgumentNullException>();
+        }
+    }
+}

--- a/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
@@ -314,7 +314,8 @@ namespace McSherry.SemanticVersioning.Monotonic
 
 
             // Metadata item is invalid
-            foreach (var item in SemanticVersionTests.InvalidMetadata)
+            foreach (var item in SemanticVersionTests.InvalidMetadata
+                                                     .Where(m => m != null))
             {
                 new Action(() => new MonotonicVersioner(true, new[] { item }))
                     .AssertThrowsExact<ArgumentException>(item);
@@ -565,7 +566,8 @@ namespace McSherry.SemanticVersioning.Monotonic
 
 
             // Metadata item is invalid
-            foreach (var item in SemanticVersionTests.InvalidMetadata)
+            foreach (var item in SemanticVersionTests.InvalidMetadata
+                                                     .Where(m => m != null))
             {
                 var iarr = new[] { item };
                 new Action(() => mv.Next(MonotonicChange.Compatible, iarr))
@@ -609,7 +611,8 @@ namespace McSherry.SemanticVersioning.Monotonic
                 .AssertThrowsExact<ArgumentException>();
 
             // Metadata item is invalid
-            foreach (var item in SemanticVersionTests.InvalidMetadata)
+            foreach (var item in SemanticVersionTests.InvalidMetadata
+                                                     .Where(m => m != null))
             {
                 var iarr = new[] { item };
                 new Action(() => mv.Next(1, MonotonicChange.Compatible, iarr))

--- a/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
@@ -687,7 +687,7 @@ namespace McSherry.SemanticVersioning.Monotonic
             // But if we advance one, it shouldn't affect the other.
             var mv1_lat = mv1.Latest;
             mv0.Next(MonotonicChange.Compatible);
-            Assert.AreEqual(new SemanticVersion(3, 7), mv0.Latest);
+            Assert.AreEqual(new SemanticVersion(1, 7), mv0.Latest);
             Assert.AreEqual(mv1_lat, mv1.Latest);
             Assert.AreNotEqual(mv0.Latest, mv1.Latest);
 

--- a/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
@@ -1,0 +1,850 @@
+﻿// Copyright (c) 2015-16 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace McSherry.SemanticVersioning.Monotonic
+{
+    /// <summary>
+    /// <para>
+    /// Provides tests for the <see cref="MonotonicVersioner"/> class.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public sealed class MonotonicVersionerTests
+    {
+        private const string Category = "Monotonic Versioning - Generator";
+
+        /// <summary>
+        /// <para>
+        /// Tests that the constructor <see cref="MonotonicVersioner()"/>
+        /// creates an instance with the expected defaults.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_Default()
+        {
+            var mv = new MonotonicVersioner();
+
+            // Compatibility component starts at one
+            Assert.AreEqual(1, mv.Compatibility);
+            Assert.AreEqual(1, mv.Latest.Major);
+
+            // Release component starts at zero
+            Assert.AreEqual(0, mv.Release);
+            Assert.AreEqual(0, mv.Latest.Minor);
+
+            // Patch component is zero
+            Assert.AreEqual(0, mv.Latest.Patch);
+
+            // No identifiers or metadata
+            Assert.IsFalse(mv.Latest.Identifiers.Any());
+            Assert.IsFalse(mv.Latest.Metadata.Any());
+
+
+            // Collection of all latest versions is populated
+            Assert.IsTrue(mv.LatestVersions.Contains(
+                new KeyValuePair<int, SemanticVersion>(
+                    1, new SemanticVersion(1, 0)
+                    )));
+
+            Assert.AreEqual(1, mv.LatestVersions.Count);
+
+
+            // Chronology contains the first version
+            Assert.IsTrue(mv.Chronology.SequenceEqual(new[]
+            {
+                new SemanticVersion(1, 0)
+            }));
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the constructor <see cref="MonotonicVersioner(bool)"/> 
+        /// correctly produces an instance where the compatibility component
+        /// is zero and not one.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_StartAtZero()
+        {
+            // These are pretty much the same tests as are in the
+            // [Create_Default] test, but with values substituted for
+            // a compatibility component that starts at zero.
+            //
+            // Check that test for appropriate comments.
+            var mv = new MonotonicVersioner(startAtOne: false);
+
+            Assert.AreEqual(0, mv.Compatibility);
+            Assert.AreEqual(0, mv.Latest.Major);
+
+            Assert.AreEqual(0, mv.Release);
+            Assert.AreEqual(0, mv.Latest.Minor);
+
+            Assert.AreEqual(0, mv.Latest.Patch);
+
+            Assert.IsFalse(mv.Latest.Identifiers.Any());
+            Assert.IsFalse(mv.Latest.Metadata.Any());
+
+
+            Assert.IsTrue(mv.LatestVersions.Contains(
+                new KeyValuePair<int, SemanticVersion>(
+                    0, new SemanticVersion(0, 0)
+                    )));
+
+            Assert.AreEqual(1, mv.LatestVersions.Count);
+
+
+            Assert.IsTrue(mv.Chronology.SequenceEqual(new[]
+            {
+                new SemanticVersion(0, 0)
+            }));
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the constructor
+        /// <see cref="MonotonicVersioner(bool, IEnumerable{String})"/>
+        /// produces an instance which is as expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_StartAtZeroAndMetadata()
+        {
+            // This constructor allows the initial version produced to
+            // be produced with the specified metadata, as well as allowing
+            // the caller to specify whether the compatibility sequence starts
+            // at one or zero.
+
+            var md = new[] { "abc", "123" };
+
+            // Ensure it works when starting at one
+            var mv0 = new MonotonicVersioner(
+                startAtOne: true,
+                metadata:   md
+                );
+            Assert.AreEqual(
+                new SemanticVersion(1, 0, 0, new string[0], md),
+                mv0.Latest
+                );
+
+            // Ensure it works when starting at zero
+            var mv1 = new MonotonicVersioner(
+                startAtOne: false,
+                metadata:   md
+                );
+            Assert.AreEqual(
+                new SemanticVersion(0, 0, 0, new string[0], md),
+                mv1.Latest
+                );
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that creating a <see cref="MonotonicVersioner"/> from
+        /// a specified chronology works as expected for basic valid
+        /// inputs.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_Chronology_Valid_Basic()
+        {
+            // Does it work at all?
+            var ch = new SemanticVersion[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 1),
+                new SemanticVersion(1, 2),
+            };
+            var mv = new MonotonicVersioner(ch);
+
+            Assert.AreEqual(1, mv.Compatibility);
+            Assert.AreEqual(2, mv.Release);
+
+            Assert.AreEqual(new SemanticVersion(1, 2), mv.Latest);
+
+            Assert.AreEqual(ch.Last(), mv.LatestVersions[1]);
+
+            Assert.IsTrue(mv.Chronology.SequenceEqual(ch));
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that creation from a chronology works for complex
+        /// valid inputs with multiple lines of compatibility.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_Chronology_Valid_Complex()
+        {
+            var ch = new SemanticVersion[]
+            {
+                /* 0 */ new SemanticVersion(1, 0),
+                /* 1 */ new SemanticVersion(1, 1),
+                /* 2 */ new SemanticVersion(2, 2), // Latest, line 2
+                /* 3 */ new SemanticVersion(1, 3),
+                /* 4 */ new SemanticVersion(3, 4),
+                /* 5 */ new SemanticVersion(3, 5), // Latest, line 3
+                /* 6 */ new SemanticVersion(1, 6), // Latest, line 1 & overall
+            };
+            var mv = new MonotonicVersioner(ch);
+
+            // [Compatibility] provides the greatest-value component
+            // yet generated by the class, not the latest component.
+            Assert.AreEqual(3, mv.Compatibility);
+            // [Release] is not related to [Compatibility], and provides
+            // the current release number.
+            Assert.AreEqual(6, mv.Release);
+
+            // [Latest] should provide the chronologically-latest version,
+            // regardless of the line of compatibility.
+            Assert.AreEqual(ch.Last(), mv.Latest);
+
+            // [LatestVersions] should, as the name might imply, provide
+            // the latest version in each line of compatibility.
+            Assert.AreEqual(ch[6], mv.LatestVersions[1]);
+            Assert.AreEqual(ch[2], mv.LatestVersions[2]);
+            Assert.AreEqual(ch[5], mv.LatestVersions[3]);
+            // Make sure these are the only keys in the collection.
+            Assert.AreEqual(3, mv.LatestVersions.Keys.Count());
+
+            // The chronology must be in order.
+            Assert.IsTrue(mv.Chronology.SequenceEqual(ch));
+        }
+        /// <summary>
+        /// <para>
+        /// The <see cref="MonotonicVersioner(IEnumerable{SemanticVersion})"/>
+        /// constructor must be able to accept an out-of-order chronology, and
+        /// this test ensures that it does.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_Chronology_Valid_Disordered()
+        {
+            var ch = new SemanticVersion[]
+            {
+                new SemanticVersion(2, 2),
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 1),
+            };
+            var mv = new MonotonicVersioner(ch);
+
+            Assert.AreEqual(2, mv.Compatibility);
+            Assert.AreEqual(2, mv.Release);
+
+            Assert.AreEqual(ch[0], mv.Latest);
+
+            Assert.AreEqual(ch[2], mv.LatestVersions[1]);
+            Assert.AreEqual(ch[0], mv.LatestVersions[2]);
+
+            Assert.AreEqual(2, mv.LatestVersions.Keys.Count());
+
+            Assert.IsTrue(mv.Chronology.SequenceEqual(
+                ch.OrderBy(sv => sv.Minor)
+                ));
+        }
+        /// <summary>
+        /// <para>
+        /// A chronology where the first line of compatibility is zero
+        /// instead of one must be considered valid.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_Chronology_Valid_StartsAtZero()
+        {
+            var ch = new SemanticVersion[]
+            {
+                new SemanticVersion(0, 0),
+                new SemanticVersion(0, 1),
+                new SemanticVersion(1, 2),
+                new SemanticVersion(2, 3),
+            };
+            var mv = new MonotonicVersioner(ch);
+
+            Assert.AreEqual(2, mv.Compatibility);
+            Assert.AreEqual(3, mv.Release);
+
+            Assert.AreEqual(ch.Last(), mv.Latest);
+
+            Assert.AreEqual(ch[1], mv.LatestVersions[0]);
+            Assert.AreEqual(ch[2], mv.LatestVersions[1]);
+            Assert.AreEqual(ch[3], mv.LatestVersions[2]);
+
+            Assert.AreEqual(3, mv.LatestVersions.Keys.Count());
+
+            Assert.IsTrue(mv.Chronology.SequenceEqual(ch));
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests the behaviour of the constructor
+        /// <see cref="MonotonicVersioner(bool, IEnumerable{String})"/> in
+        /// response to invalid inputs.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_StartAtZeroAndMetadata_Invalid()
+        {
+            // Collection of metadata items is null
+            new Action(() => new MonotonicVersioner(true, null))
+                .AssertThrows<ArgumentNullException>();
+
+            // Item within collection of metadata items is null
+            var narr = new string[] { null };
+            new Action(() => new MonotonicVersioner(true, narr))
+                .AssertThrows<ArgumentNullException>();
+
+
+            // Metadata item is invalid
+            foreach (var item in SemanticVersionTests.InvalidMetadata)
+            {
+                new Action(() => new MonotonicVersioner(true, new[] { item }))
+                    .AssertThrowsExact<ArgumentException>(item);
+            }
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that creation with an invalid chronology fails
+        /// as is expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Create_Chronology_Invalid()
+        {
+            // Chronology is null
+            new Action(() => new MonotonicVersioner(chronology: null))
+                .AssertThrows<ArgumentNullException>();
+
+            // Chronology has a null item
+            var nullarr = new SemanticVersion[] { null };
+            new Action(() => new MonotonicVersioner(nullarr))
+                .AssertThrows<ArgumentNullException>();
+
+
+            // Chronology contains a non-monotonic version
+            var nonmon = new[] { new SemanticVersion(1, 0, 1) };
+            new Action(() => new MonotonicVersioner(nonmon))
+                .AssertThrows<ArgumentOutOfRangeException>();
+
+
+            // Chronology is incomplete, missing a compatibility number
+            var incComp = new[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(3, 1),
+            };
+            new Action(() => new MonotonicVersioner(incComp))
+                .AssertThrowsExact<ArgumentException>();
+
+            // Chronology is incomplete, missing a release number
+            var incRel = new[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 2),
+            };
+            new Action(() => new MonotonicVersioner(incRel))
+                .AssertThrowsExact<ArgumentException>();
+
+            // Chronology is incomplete, compatibility does not start at zero
+            var incNonZ = new[] { new SemanticVersion(2, 0) };
+            new Action(() => new MonotonicVersioner(incNonZ))
+                .AssertThrowsExact<ArgumentException>();
+
+            // Chronology is incomplete, empty collection
+            var incEmpty = Enumerable.Empty<SemanticVersion>();
+            new Action(() => new MonotonicVersioner(incEmpty))
+                .AssertThrowsExact<ArgumentException>();
+        }
+
+
+        /// <summary>
+        /// <para>
+        /// Tests that the method to retrieve the next version accepting
+        /// a <see cref="MonotonicChange"/> behaves as anticipated for
+        /// correct inputs.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_ChangeOnly_Valid()
+        {
+            var mv = new MonotonicVersioner();
+
+            // A compatible change increments only the release number
+            Assert.AreEqual(
+                new SemanticVersion(1, 1), mv.Next(MonotonicChange.Compatible)
+                );
+
+            // A breaking change increments both the release number and the
+            // compatibility number.
+            Assert.AreEqual(
+                new SemanticVersion(2, 2), mv.Next(MonotonicChange.Breaking)
+                );
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method for retrieving the next version accepting
+        /// a change type and collection of metadata items will behave as
+        /// expected for valid input.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_ChangeAndMetadata_Valid()
+        {
+            var mv = new MonotonicVersioner();
+
+            // Compatible change
+            var sv0 = new SemanticVersion(
+                major:       1,
+                minor:       1,
+                patch:       0,
+                identifiers: new string[0],
+                metadata:    new[] { "abc", "123" }
+                );
+            Assert.AreEqual(
+                sv0, mv.Next(MonotonicChange.Compatible, new[] { "abc", "123" })
+                );
+
+            // Breaking change
+            var sv1 = new SemanticVersion(
+                major:       2,
+                minor:       2,
+                patch:       0,
+                identifiers: new string[0],
+                metadata:    new[] { "abc", "123" }
+                );
+            Assert.AreEqual(
+                sv1, mv.Next(MonotonicChange.Breaking, new[] { "abc", "123" })
+                );
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method to retrieve the next version accepting a
+        /// collection of metadata items behaves correctly for valid input.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_LineAndMetadata_Valid()
+        {
+            var mv = new MonotonicVersioner();
+
+            var md = new[] { "abc", "123" };
+
+            // Compatible changes
+            Assert.AreEqual(
+                new SemanticVersion(1, 1, 0, new string[0], md),
+                mv.Next(1, MonotonicChange.Compatible, md)
+                );
+
+            // Breaking changes
+            Assert.AreEqual(
+                new SemanticVersion(2, 2, 0, new string[0], md),
+                mv.Next(1, MonotonicChange.Breaking, md)
+                );
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method to retrieve the next version accepting both a
+        /// line number and a <see cref="MonotonicChange"/> behaves correctly for
+        /// valid inputs.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_ChangeAndLine_Valid()
+        {
+            var mv = new MonotonicVersioner();
+
+            // A compatible change increments only the release number.
+            Assert.AreEqual(
+                new SemanticVersion(1, 1),
+                mv.Next(1, MonotonicChange.Compatible)
+                );
+
+            // A breaking change increments compatibility and release numbers.
+            Assert.AreEqual(
+                new SemanticVersion(2, 2),
+                mv.Next(1, MonotonicChange.Breaking)
+                );
+
+            // But having released a breaking change does not preclude
+            // updating a previous line of compatibility.
+            Assert.AreEqual(
+                new SemanticVersion(1, 3),
+                mv.Next(1, MonotonicChange.Compatible)
+                );
+
+            // Nor does updating an older release preclude updating a newer one.
+            Assert.AreEqual(
+                new SemanticVersion(2, 4),
+                mv.Next(2, MonotonicChange.Compatible)
+                );
+
+            // And specifying another breaking change on an older line of
+            // compatibility should increment the compatibility number.
+            Assert.AreEqual(
+                new SemanticVersion(3, 5),
+                mv.Next(1, MonotonicChange.Breaking)
+                );
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests the behaviour of the
+        /// <see cref="MonotonicVersioner.Next(MonotonicChange)"/> method
+        /// in response to invalid input.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_ChangeOnly_Invalid()
+        {
+            var mv = new MonotonicVersioner();
+
+            // Specified change is not a recognised value
+            new Action(() => mv.Next((MonotonicChange)Int32.MinValue))
+                .AssertThrows<ArgumentOutOfRangeException>();
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method <see cref="MonotonicVersioner.
+        /// Next(MonotonicChange, IEnumerable{string})"/> responds in
+        /// the manner expected when given invalid input.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_ChangeAndMetadata_Invalid()
+        {
+            var mv = new MonotonicVersioner();
+            var valarr = new[] { "abc", "123" };
+
+            // Change type is invalid
+            new Action(() => mv.Next((MonotonicChange)Int32.MinValue, valarr))
+                .AssertThrows<ArgumentOutOfRangeException>();
+
+
+            // Metadata collection is null
+            new Action(() => mv.Next(MonotonicChange.Compatible, null))
+                .AssertThrows<ArgumentNullException>();
+
+            // Metadata item is null
+            var nularr = new string[] { null };
+            new Action(() => mv.Next(MonotonicChange.Compatible, nularr))
+                .AssertThrows<ArgumentNullException>();
+
+
+            // Metadata item is invalid
+            foreach (var item in SemanticVersionTests.InvalidMetadata)
+            {
+                var iarr = new[] { item };
+                new Action(() => mv.Next(MonotonicChange.Compatible, iarr))
+                    .AssertThrowsExact<ArgumentException>(item);
+            }
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method for retrieving the next version accepting
+        /// a compatibility line and collection of metadata will respond to
+        /// invalid input in the manner expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_LineAndMetadata_Invalid()
+        {
+            var mv = new MonotonicVersioner();
+            var valarr = new string[] { "abc", "123" };
+            var nularr = new string[] { null };
+
+            // Line is negative
+            new Action(() => mv.Next(-1, MonotonicChange.Compatible, valarr))
+                .AssertThrows<ArgumentOutOfRangeException>();
+
+            // Change type is not valid
+            new Action(() => mv.Next(1, (MonotonicChange)Int32.MinValue, valarr))
+                .AssertThrows<ArgumentOutOfRangeException>();
+
+
+            // Metadata collection is null
+            new Action(() => mv.Next(1, MonotonicChange.Compatible, null))
+                .AssertThrows<ArgumentNullException>();
+
+            // Item in metadata collection is null
+            new Action(() => mv.Next(1, MonotonicChange.Compatible, nularr))
+                .AssertThrows<ArgumentNullException>();
+
+
+            // Line is not a current line of compatibility
+            new Action(() => mv.Next(100, MonotonicChange.Compatible, valarr))
+                .AssertThrowsExact<ArgumentException>();
+
+            // Metadata item is invalid
+            foreach (var item in SemanticVersionTests.InvalidMetadata)
+            {
+                var iarr = new[] { item };
+                new Action(() => mv.Next(1, MonotonicChange.Compatible, iarr))
+                    .AssertThrowsExact<ArgumentException>(item);
+            }
+        }
+        /// <summary>
+        /// <para>
+        /// Tests that the method for generating the next version accepting
+        /// a compatibility line number and change responds as expected for
+        /// invalid inputs.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Next_ChangeAndLine_Invalid()
+        {
+            var mv = new MonotonicVersioner();
+
+            // Line is negative
+            new Action(() => mv.Next(-1, MonotonicChange.Compatible))
+                .AssertThrows<ArgumentOutOfRangeException>();
+
+            // Type of change is not recognised
+            new Action(() => mv.Next(1, (MonotonicChange)Int32.MinValue))
+                .AssertThrows<ArgumentOutOfRangeException>();
+
+
+            // Line is not a line present in the versioner
+            new Action(() => mv.Next(100, MonotonicChange.Compatible))
+                .AssertThrowsExact<ArgumentException>();
+        }
+
+
+        /// <summary>
+        /// <para>
+        /// Tests that the <see cref="MonotonicVersioner.Clone"/> method
+        /// behaves as expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Clone()
+        {
+            var seed = new SemanticVersion[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 1),
+                new SemanticVersion(1, 2),
+                new SemanticVersion(2, 3),
+                new SemanticVersion(2, 4),
+                new SemanticVersion(3, 5),
+                new SemanticVersion(1, 6),
+            };
+
+            var mv0 = new MonotonicVersioner(seed);
+
+
+            // Here we go.
+            var mv1 = mv0.Clone();
+
+            // The instances should not be the same instance.
+            Assert.IsFalse(object.ReferenceEquals(mv0, mv1));
+
+            // But they should start with the same chronology.
+            Assert.IsTrue(mv0.Chronology.SequenceEqual(mv1.Chronology));
+
+            // And should have the same values for other properties.
+            Assert.AreEqual(mv0.Latest, mv1.Latest);
+            Assert.AreEqual(mv0.Compatibility, mv1.Compatibility);
+            Assert.AreEqual(mv0.Release, mv1.Release);
+            Assert.IsTrue(mv0.LatestVersions.SequenceEqual(mv1.LatestVersions));
+
+            // But if we advance one, it shouldn't affect the other.
+            var mv1_lat = mv1.Latest;
+            mv0.Next(MonotonicChange.Compatible);
+            Assert.AreEqual(new SemanticVersion(3, 7), mv0.Latest);
+            Assert.AreEqual(mv1_lat, mv1.Latest);
+            Assert.AreNotEqual(mv0.Latest, mv1.Latest);
+
+            var mv0_lat = mv0.Latest;
+            mv1.Next(MonotonicChange.Breaking);
+            Assert.AreEqual(new SemanticVersion(4, 7), mv1.Latest);
+            Assert.AreEqual(mv0_lat, mv0.Latest);
+            Assert.AreNotEqual(mv0.Latest, mv1.Latest);
+        }
+
+
+        /// <summary>
+        /// <para>
+        /// Tests that the <see cref="MonotonicVersioner.Latest"/> property
+        /// behaves as expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Latest()
+        {
+            // [Latest] provides the chronologically-latest version
+            // created by the instance. That is, the version with the
+            // greatest-value release number, regardless of line of
+            // compatibility.
+            var mv = new MonotonicVersioner();
+
+            // Starts at the initial version
+            Assert.AreEqual((SemanticVersion)"1.0", mv.Latest);
+
+            // Updated on a compatible change
+            mv.Next(MonotonicChange.Compatible);
+            Assert.AreEqual((SemanticVersion)"1.1", mv.Latest);
+
+            // Updated on a breaking change
+            mv.Next(MonotonicChange.Breaking);
+            Assert.AreEqual((SemanticVersion)"2.2", mv.Latest);
+
+            // Updating a lower-value line of compatibility produces
+            // the correct result.
+            mv.Next(1, MonotonicChange.Compatible);
+            Assert.AreEqual((SemanticVersion)"1.3", mv.Latest);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests that the <see cref="MonotonicVersioner.LatestVersions"/>
+        /// property's behaviour is as expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_LatestVersions()
+        {
+            // The [LatestVersions] property provides a dictionary
+            // where the key is the line of compatibility and the
+            // version is the latest version produced in that line.
+            var mv = new MonotonicVersioner();
+
+
+            // Expected initial value.
+            Assert.AreEqual(1, mv.LatestVersions.Count);
+            Assert.IsTrue(mv.LatestVersions.ContainsKey(1));
+            Assert.AreEqual((SemanticVersion)"1.0", mv.LatestVersions[1]);
+
+            // Value updates with compatible change
+            mv.Next(MonotonicChange.Compatible);
+
+            Assert.AreEqual(1, mv.LatestVersions.Count);
+            Assert.IsTrue(mv.LatestVersions.ContainsKey(1));
+            Assert.AreEqual((SemanticVersion)"1.1", mv.LatestVersions[1]);
+
+            // Value updates with breaking change
+            mv.Next(MonotonicChange.Breaking);
+
+            Assert.AreEqual(2, mv.LatestVersions.Count);
+            Assert.IsTrue(mv.LatestVersions.ContainsKey(1));
+            Assert.IsTrue(mv.LatestVersions.ContainsKey(2));
+            Assert.AreEqual((SemanticVersion)"1.1", mv.LatestVersions[1]);
+            Assert.AreEqual((SemanticVersion)"2.2", mv.LatestVersions[2]);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests that the <see cref="MonotonicVersioner.Compatibility"/>
+        /// property acts in the manner expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Compatibility()
+        {
+            // The [Compatibility] property gives the greatest line of
+            // compatibility present in a version created by the instance.
+            var mv = new MonotonicVersioner();
+
+            // Starts off as expected
+            Assert.AreEqual(1, mv.Compatibility);
+
+            // Does not increment with a compatible change
+            mv.Next(MonotonicChange.Compatible);
+            Assert.AreEqual(1, mv.Compatibility);
+
+            // Does increment with a breaking change
+            mv.Next(MonotonicChange.Breaking);
+            Assert.AreEqual(2, mv.Compatibility);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests the behaviour of the <see cref="MonotonicVersioner.Release"/>
+        /// property.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Release()
+        {
+            // The [Release] property tracks the current release number,
+            // and is incremented with each new version generated.
+            var mv = new MonotonicVersioner();
+
+            // Starts off as expected
+            Assert.AreEqual(0, mv.Release);
+
+            // Increments with a compatible release
+            mv.Next(MonotonicChange.Compatible);
+            Assert.AreEqual(1, mv.Release);
+
+            // Increments with a breaking release
+            mv.Next(MonotonicChange.Breaking);
+            Assert.AreEqual(2, mv.Release);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests the behaviour of the <see cref="MonotonicVersioner.
+        /// Chronology"/> property.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void General_Chronology()
+        {
+            // The [Chronology] property provides an ordered
+            // record of the versions created by the instance.
+            var mv = new MonotonicVersioner();
+
+            // Chronology starts with only the initial version
+            Assert.IsTrue(mv.Chronology.SequenceEqual(new[]
+            {
+                new SemanticVersion(1, 0),
+            }));
+
+            // Compatible change adds to the chronology
+            mv.Next(MonotonicChange.Compatible);
+            Assert.IsTrue(mv.Chronology.SequenceEqual(new[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 1),
+            }));
+
+            // Breaking change adds to the chronology
+            mv.Next(MonotonicChange.Breaking);
+            Assert.IsTrue(mv.Chronology.SequenceEqual(new[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 1),
+                new SemanticVersion(2, 2),
+            }));
+
+            // A second compatible change produces a chronology
+            // with the correct ordering
+            mv.Next(1, MonotonicChange.Compatible);
+            Assert.IsTrue(mv.Chronology.SequenceEqual(new[]
+            {
+                new SemanticVersion(1, 0),
+                new SemanticVersion(1, 1),
+                new SemanticVersion(2, 2),
+                new SemanticVersion(1, 3),
+            }));
+        }
+    }
+}

--- a/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
+++ b/libSemVer.NET.Testing/Monotonic/MonotonicVersionerTests.cs
@@ -397,6 +397,19 @@ namespace McSherry.SemanticVersioning.Monotonic
             Assert.AreEqual(
                 new SemanticVersion(2, 2), mv.Next(MonotonicChange.Breaking)
                 );
+
+            // A change is applied to the latest version.
+            Assert.AreEqual(
+                new SemanticVersion(2, 3), mv.Next(MonotonicChange.Compatible)
+                );
+
+            // A change is applied to the latest version.
+            // This call makes the latest version "1.4".
+            mv.Next(1, MonotonicChange.Compatible);
+            // So this call should result in 1.5.
+            Assert.AreEqual(
+                new SemanticVersion(1, 5), mv.Next(MonotonicChange.Compatible)
+                );
         }
         /// <summary>
         /// <para>
@@ -411,27 +424,30 @@ namespace McSherry.SemanticVersioning.Monotonic
             var mv = new MonotonicVersioner();
 
             // Compatible change
-            var sv0 = new SemanticVersion(
-                major:       1,
-                minor:       1,
-                patch:       0,
-                identifiers: new string[0],
-                metadata:    new[] { "abc", "123" }
-                );
+            var sv0 = (SemanticVersion)"1.1+abc.123";
             Assert.AreEqual(
                 sv0, mv.Next(MonotonicChange.Compatible, new[] { "abc", "123" })
                 );
 
             // Breaking change
-            var sv1 = new SemanticVersion(
-                major:       2,
-                minor:       2,
-                patch:       0,
-                identifiers: new string[0],
-                metadata:    new[] { "abc", "123" }
-                );
+            var sv1 = (SemanticVersion)"2.2+abc.123";
             Assert.AreEqual(
                 sv1, mv.Next(MonotonicChange.Breaking, new[] { "abc", "123" })
+                );
+
+            // Change applies to latest version.
+            var sv2 = (SemanticVersion)"2.3+def.456";
+            Assert.AreEqual(
+                sv2, mv.Next(MonotonicChange.Compatible, new[] { "def", "456" })
+                );
+
+            // Change applies to latest version.
+            // This call causes the latest version to be in the 1.x line.
+            mv.Next(1, MonotonicChange.Compatible);
+            // Thus, this call should return another version in the 1.x line.
+            var sv3 = (SemanticVersion)"1.5+ghi.789";
+            Assert.AreEqual(
+                sv3, mv.Next(MonotonicChange.Compatible, new[] { "ghi", "789" })
                 );
         }
         /// <summary>

--- a/libSemVer.NET.Testing/SemanticVersionTests.cs
+++ b/libSemVer.NET.Testing/SemanticVersionTests.cs
@@ -38,6 +38,22 @@ namespace McSherry.SemanticVersioning
     {
         private const string Category = "Semantic Version Base";
 
+        public static IEnumerable<string> InvalidMetadata
+            => new string[]
+            {
+                "",                         // 0
+                null,                       // 1
+                " ",                        // 2
+                "infix space",              // 3
+                " leading space",           // 4
+                "trailing space ",          // 5
+                " leading and trailing ",   // 6
+                "Tür",                      // 7
+                "jalapeño",                 // 8
+                "çava",                     // 9
+                "?",                        // 10
+            };
+
         /// <summary>
         /// <para>
         /// Tests that validation of build metadata items is working
@@ -77,28 +93,15 @@ namespace McSherry.SemanticVersioning
                     $"Unexpected rejection: item {i} (\"{validItems[i]}\")."
                     );
             }
-
-            var invItems = new string[]
-            {
-                "",                         // 0
-                null,                       // 1
-                " ",                        // 2
-                "infix space",              // 3
-                " leading space",           // 4
-                "trailing space ",          // 5
-                " leading and trailing ",   // 6
-                "Tür",                      // 7
-                "jalapeño",                 // 8
-                "çava",                     // 9
-                "?",                        // 10
-            };
-            // Iterate through all the items we expect to be invalid.
-            for (int i = 0; i < invItems.Length; i++)
+            
+            // Iterate through all invalid metadata items and check that
+            // they are not considered valid.
+            foreach (var item in InvalidMetadata)
             {
                 Assert.IsFalse(
-                    Helper.IsValidIdentifier(invItems[i]),
-                    $"Unexpected acceptance: item {i} (\"{invItems[i]}\")."
-                    );
+                    Helper.IsValidMetadata(item),
+                   $@"Unexpected acceptance: item ""{item}"""
+                   );
             }
         }
         /// <summary>

--- a/libSemVer.NET.Testing/TestingExtensions.cs
+++ b/libSemVer.NET.Testing/TestingExtensions.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -172,6 +173,46 @@ namespace McSherry.SemanticVersioning
                                             T comparand)
         {
             int comparison = comparable.CompareTo(comparand);
+
+            if (comparison < 0)
+                return Ordering.Lesser;
+            else if (comparison > 0)
+                return Ordering.Greater;
+            else
+                return Ordering.Equal;
+        }
+        /// <summary>
+        /// <para>
+        /// Compares the provided <typeparamref name="T"/> using the
+        /// specified <see cref="IComparer{T}"/> and returns an
+        /// <see cref="Ordering"/> indicating their relation.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the objects to be compared.
+        /// </typeparam>
+        /// <param name="comparer">
+        /// The comparer to use when comparing <paramref name="x"/>
+        /// and <paramref name="y"/>.
+        /// </param>
+        /// <param name="x">
+        /// An object to compare to <paramref name="y"/> using
+        /// <paramref name="comparer"/>.
+        /// </param>
+        /// <param name="y">
+        /// An object to compare to <paramref name="x"/> using
+        /// <paramref name="comparer"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="Ordering"/> indicating the relation of
+        /// <paramref name="x"/> and <paramref name="y"/> when compared
+        /// with <paramref name="comparer"/>.
+        /// </returns>
+        public static Ordering UseToCompare<T>(
+            this IComparer<T> comparer, T x, T y
+            )
+        {
+            int comparison = comparer.Compare(x, y);
 
             if (comparison < 0)
                 return Ordering.Lesser;

--- a/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
+++ b/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
@@ -58,6 +58,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Monotonic\MonotonicComparerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Ranges\RangeIntlParsingTests.cs" />
     <Compile Include="Ranges\RangeTests.cs" />
@@ -72,9 +73,7 @@
       <Name>McSherry.SemanticVersioning</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Monotonic\" />
-  </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
+++ b/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Monotonic\MonotonicComparerTests.cs" />
     <Compile Include="Monotonic\MonotonicExtensionsTests.cs" />
+    <Compile Include="Monotonic\MonotonicVersionerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Ranges\RangeIntlParsingTests.cs" />
     <Compile Include="Ranges\RangeTests.cs" />

--- a/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
+++ b/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
@@ -59,6 +59,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Monotonic\MonotonicComparerTests.cs" />
+    <Compile Include="Monotonic\MonotonicExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Ranges\RangeIntlParsingTests.cs" />
     <Compile Include="Ranges\RangeTests.cs" />

--- a/libSemVer.NET/McSherry.SemanticVersioning.csproj
+++ b/libSemVer.NET/McSherry.SemanticVersioning.csproj
@@ -47,6 +47,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helper.cs" />
+    <Compile Include="Monotonic\MonotonicComparer.cs" />
+    <Compile Include="Monotonic\MonotonicExtensions.cs" />
+    <Compile Include="Monotonic\MonotonicVersioner.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Ranges\VersionRange.Comparison.cs" />
     <Compile Include="Ranges\VersionRange.cs" />

--- a/libSemVer.NET/Monotonic/MonotonicComparer.cs
+++ b/libSemVer.NET/Monotonic/MonotonicComparer.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) 2015-16 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McSherry.SemanticVersioning.Monotonic
+{
+    /// <summary>
+    /// <para>
+    /// Represents a semantic version comparison operation using
+    /// monotonic versioning comparison rules.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This class compares monotonic versions as set out by the
+    /// Monotonic Versioning Manifesto 1.2.
+    /// </remarks>
+    [CLSCompliant(true)]
+    public sealed class MonotonicComparer
+        : IComparer<SemanticVersion>
+    {
+        /// <summary>
+        /// <para>
+        /// A <see cref="MonotonicComparer"/> which compares using the
+        /// standard rules for monotonic versions.
+        /// </para>
+        /// </summary>
+        public static MonotonicComparer Standard
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private MonotonicComparer()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Compares two monotonic versions and returns an indication
+        /// of their relative order.
+        /// </para>
+        /// </summary>
+        /// <param name="x">
+        /// A monotonic version to compare to <paramref name="y"/>.
+        /// </param>
+        /// <param name="y">
+        /// A monotonic version to compare to <paramref name="x"/>.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// A value less than zero if <paramref name="x"/> precedes
+        /// <paramref name="y"/> in sort order, or if
+        /// <paramref name="x"/> is null and <paramref name="y"/>
+        /// is not null.
+        /// </para>
+        /// <para>
+        /// Zero if <paramref name="x"/> is equal to <paramref name="y"/>,
+        /// including if both are null.
+        /// </para>
+        /// <para>
+        /// A value greater than zero if <paramref name="x"/> follows
+        /// <paramref name="y"/> in sort order, or if <paramref name="y"/>
+        /// is null and <paramref name="x"/> is not null.
+        /// </para>
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="x"/> or <paramref name="y"/> is not a valid
+        /// monotonic version.
+        /// </exception>
+        public int Compare(SemanticVersion x, SemanticVersion y)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/libSemVer.NET/Monotonic/MonotonicComparer.cs
+++ b/libSemVer.NET/Monotonic/MonotonicComparer.cs
@@ -39,23 +39,20 @@ namespace McSherry.SemanticVersioning.Monotonic
     public sealed class MonotonicComparer
         : IComparer<SemanticVersion>
     {
+        private static readonly MonotonicComparer 
+            _standard = new MonotonicComparer();
+
         /// <summary>
         /// <para>
         /// A <see cref="MonotonicComparer"/> which compares using the
         /// standard rules for monotonic versions.
         /// </para>
         /// </summary>
-        public static MonotonicComparer Standard
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public static MonotonicComparer Standard => _standard;
 
         private MonotonicComparer()
         {
-            throw new NotImplementedException();
+
         }
 
         /// <summary>
@@ -93,7 +90,106 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// </exception>
         public int Compare(SemanticVersion x, SemanticVersion y)
         {
-            throw new NotImplementedException();
+            const string NonMonMsg =
+                "A non-monotonic version cannot be compared using " +
+                nameof(MonotonicComparer) + ".";
+
+            const int XGreater = +1;
+            const int Equal    =  0;
+            const int YGreater = -1;
+
+            if (x != null && !x.IsMonotonic())
+            {
+                throw new ArgumentException(
+                    message:    NonMonMsg,
+                    paramName:  nameof(x)
+                    );
+            }
+
+            if (y != null && !y.IsMonotonic())
+            {
+                throw new ArgumentException(
+                    message:    NonMonMsg,
+                    paramName:  nameof(y)
+                    );
+            }
+
+            // If only one of the parameters is null, the null
+            // one will have precedence.
+            if (x == null ^ y == null)
+                return x == null ? XGreater : YGreater;
+
+            // If both are equal (including if both are null), then
+            // the parameters have the same precedence.
+            if (x == y)
+                return Equal;
+
+            // If the compatibility components differ, the numerically
+            // larger one has precedence.
+            if (x.Major > y.Major)
+                return XGreater;
+            else if (x.Major < y.Major)
+                return YGreater;
+
+            // If the release components differ, the numerically larger
+            // one takes precedence.
+            if (x.Minor > y.Minor)
+                return XGreater;
+            else if (x.Minor < y.Minor)
+                return YGreater;
+
+            // Metadata is compared lexically, and the later-sorted
+            // version takes precedence. We'll assume that "lexically"
+            // means "with ASCII sort order" like in the Semantic
+            // Versioning specification, since that's what Monotonic
+            // Versioning is based on and the manifesto does not make
+            // any more-specific requirements.
+
+            // If the metadata collections are of equal length, check
+            // to see whether they contain the same items. If they do,
+            // the versions have equal precedence.
+            if (x.Metadata.Count == y.Metadata.Count &&
+                x.Metadata.SequenceEqual(y.Metadata))
+                return Equal;
+
+            using (var xe = x.Metadata.GetEnumerator())
+            using (var ye = y.Metadata.GetEnumerator())
+            {
+                // Iterate through both metadata collections at once.
+                while (xe.MoveNext() & ye.MoveNext())
+                {
+                    // We're looking for the first difference, so
+                    // we continue to the next iteration if the items
+                    // are equal.
+                    if (xe.Current == ye.Current)
+                        continue;
+
+                    // If we're here, we've found a difference.
+                    //
+                    // The manifesto specifies lexical ordering, which
+                    // we'll take to mean "ASCII sort order" since it
+                    // isn't any more specific and that's what Semantic
+                    // Versioning uses.
+                    //
+                    // The later-sorted one has precedence.
+                    return String.CompareOrdinal(xe.Current, ye.Current);
+                }
+
+                // If we end up here, one collection is longer than the other.
+                // We also know that the larger collection is a superset of
+                // the smaller one, otherwise we wouldn't have ended up here.
+                //
+                // We're going to use the lengths of the collections to
+                // determine precedence, sorting the shorter collection before
+                // the longer one due to the requirement that the lexically-
+                // later-sorted version takes precedence.
+                if (x.Metadata.Count < y.Metadata.Count)
+                    return XGreater;
+                // We already know that the collections are not equal, so
+                // we don't need to check again here.
+                else
+                    return YGreater;
+            }
         }
     }
 }

--- a/libSemVer.NET/Monotonic/MonotonicExtensions.cs
+++ b/libSemVer.NET/Monotonic/MonotonicExtensions.cs
@@ -51,6 +51,13 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// True if <paramref name="version"/> is a valid monotonic version,
         /// false if otherwise.
         /// </returns>
+        /// <remarks>
+        /// <para>
+        /// A <see cref="SemanticVersion"/> is considered a valid monotonic
+        /// version if it: has no <see cref="SemanticVersion.Patch"/> component;
+        /// and has no <see cref="SemanticVersion.Identifiers"/>.
+        /// </para>
+        /// </remarks>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="version"/> is null.
         /// </exception>

--- a/libSemVer.NET/Monotonic/MonotonicExtensions.cs
+++ b/libSemVer.NET/Monotonic/MonotonicExtensions.cs
@@ -63,7 +63,16 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// </exception>
         public static bool IsMonotonic(this SemanticVersion version)
         {
-            throw new NotImplementedException();
+            if (version == null)
+            {
+                throw new ArgumentNullException(
+                    message:    "The specified version cannot be null.",
+                    paramName:  nameof(version)
+                    );
+            }
+
+            return version.Patch == 0 &&
+                   version.Identifiers.Count == 0;
         }
     }
 }

--- a/libSemVer.NET/Monotonic/MonotonicExtensions.cs
+++ b/libSemVer.NET/Monotonic/MonotonicExtensions.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2015-16 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McSherry.SemanticVersioning.Monotonic
+{
+    /// <summary>
+    /// <para>
+    /// Provides extension methods related to treating 
+    /// <see cref="SemanticVersion"/>s as monotonic versions.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// The methods this class provides are based on the
+    /// Monotonic Versioning Manifesto 1.2.
+    /// </remarks>
+    [CLSCompliant(true)]
+    public static class MonotonicExtensions
+    {
+        /// <summary>
+        /// <para>
+        /// Determines whether a <see cref="SemanticVersion"/> is a valid
+        /// monotonic version.
+        /// </para>
+        /// </summary>
+        /// <param name="version">
+        /// The <see cref="SemanticVersion"/> to be checked.
+        /// </param>
+        /// <returns>
+        /// True if <paramref name="version"/> is a valid monotonic version,
+        /// false if otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="version"/> is null.
+        /// </exception>
+        public static bool IsMonotonic(this SemanticVersion version)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -215,10 +215,6 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// are to start at one or zero. It is assumed that either is valid 
         /// as neither is specifically recommended nor prohibited.
         /// </para>
-        /// <para>
-        /// If the <see cref="Compatibility"/> components are to start at
-        /// one, <see cref="MonotonicVersioner()"/> may be used.
-        /// </para>
         /// </remarks>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="metadata"/> or an item thereof is null.

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -80,33 +80,6 @@ namespace McSherry.SemanticVersioning.Monotonic
     {
         /// <summary>
         /// <para>
-        /// Sorts a collection of <see cref="SemanticVersion"/>s using 
-        /// monotonic versioning sorting rules.
-        /// </para>
-        /// </summary>
-        /// <param name="versions">
-        /// The versions to be sorted.
-        /// </param>
-        /// <returns>
-        /// A sorted collection of <see cref="SemanticVersion"/>s, with the
-        /// highest-precedence version first in the collection.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="versions"/> or an item therein is null.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// One of more of the items within <paramref name="versions"/> is
-        /// not a valid monotonic version.
-        /// </exception>
-        public static IEnumerable<SemanticVersion> Sort(
-            IEnumerable<SemanticVersion> versions
-            )
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <para>
         /// Creates a new <see cref="MonotonicVersioner"/> instance.
         /// </para>
         /// </summary>

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -1,0 +1,388 @@
+﻿// Copyright (c) 2015-16 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McSherry.SemanticVersioning.Monotonic
+{
+    /// <summary>
+    /// <para>
+    /// The types of change which may be made to a monotonic-versioned
+    /// software package.
+    /// </para>
+    /// </summary>
+    public enum MonotonicChange
+    {
+        /// <summary>
+        /// <para>
+        /// A backwards-compatible change, where the change would not
+        /// break existing uses of the software package's API.
+        /// </para>
+        /// </summary>
+        Compatible,
+        /// <summary>
+        /// <para>
+        /// A breaking change, where the change will break existing uses
+        /// of the software package's API.
+        /// </para>
+        /// </summary>
+        Breaking,
+    }
+
+    /// <summary>
+    /// <para>
+    /// Provides a method of working with <see cref="SemanticVersion"/>s as
+    /// monotonic versions.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Monotonic Versioning is a simplified versioning scheme that
+    /// is compatible with Semantic Versioning 2.0.0. The scheme uses
+    /// two components: compatibility, indicating a "line of compatibility"
+    /// where all versions with the same component are compatible; and
+    /// release, which is incremented with every release, regardless of
+    /// the line of compatibility.
+    /// </para>
+    /// <para>
+    /// For example, a first release would be "1.0". A backwards-compatible
+    /// update to this would be "1.1". If a breaking change was made, that
+    /// release would be "2.2". However, if the first line of compatibility
+    /// was updated again, it would be "1.3".
+    /// </para>
+    /// <para>
+    /// The full manifesto is available from the Applied Computer Science
+    /// Lab website. This class is based on the 1.2 manifesto.
+    /// </para>
+    /// </remarks>
+    [CLSCompliant(true)]
+    public sealed partial class MonotonicVersioner
+    {
+        /// <summary>
+        /// <para>
+        /// Sorts a collection of <see cref="SemanticVersion"/>s using 
+        /// monotonic versioning sorting rules.
+        /// </para>
+        /// </summary>
+        /// <param name="versions">
+        /// The versions to be sorted.
+        /// </param>
+        /// <returns>
+        /// A sorted collection of <see cref="SemanticVersion"/>s, with the
+        /// highest-precedence version first in the collection.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="versions"/> or an item therein is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One of more of the items within <paramref name="versions"/> is
+        /// not a valid monotonic version.
+        /// </exception>
+        public static IEnumerable<SemanticVersion> Sort(
+            IEnumerable<SemanticVersion> versions
+            )
+        {
+            throw new NotImplementedException();
+        }
+
+
+        /// <summary>
+        /// <para>
+        /// Returns the next version number when a specified change is
+        /// made to the latest version.
+        /// </para>
+        /// </summary>
+        /// <param name="change">
+        /// The type of change being made to the latest version.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// The next version number produced when the specified change
+        /// is made to the latest version.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Compatible"/>, the release number
+        /// is incremented but the compatibility number remains the same.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Breaking"/>, both the release and
+        /// compatibility numbers are incremented.
+        /// </para>
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para>
+        /// <paramref name="change"/> is not a recognised type of change.
+        /// </para>
+        /// </exception>
+        public SemanticVersion Next(MonotonicChange change)
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Returns the next version number when a specified change is
+        /// made to the latest version.
+        /// </para>
+        /// </summary>
+        /// <param name="change">
+        /// The type of change being made to the latest version.
+        /// </param>
+        /// <param name="metadata">
+        /// The metadata to be included with the new version.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// The next version number produced when the specified change
+        /// is made to the latest version.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Compatible"/>, the release number
+        /// is incremented but the compatibility number remains the same.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Breaking"/>, both the release and
+        /// compatibility numbers are incremented.
+        /// </para>
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para>
+        /// <paramref name="change"/> is not a recognised type of change.
+        /// </para>
+        /// </exception>        
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="metadata"/> or an item therein is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One or more items within <paramref name="metadata"/> is not a
+        /// valid metadata string.
+        /// </exception>
+        public SemanticVersion Next(
+            MonotonicChange change, IEnumerable<string> metadata
+            )
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Returns the next version number when a specified change is
+        /// made to a given line of compatibility.
+        /// </para>
+        /// </summary>
+        /// <param name="line">
+        /// The line of compatibility to which the change is being
+        /// made.
+        /// </param>
+        /// <param name="change">
+        /// The type of change being made to <paramref name="line"/>.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// The next version number produced when the specified change
+        /// is made to the specified line of compatibility.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Compatible"/>, the release number
+        /// is incremented but the compatibility number remains the same.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Breaking"/>, both the release and
+        /// compatibility numbers are incremented.
+        /// </para>
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para>
+        /// <paramref name="line"/> is negative.
+        /// </para>
+        /// <para>
+        /// <paramref name="line"/> is not a current line of compatibility.
+        /// </para>
+        /// <para>
+        /// <paramref name="change"/> is not a recognised type of change.
+        /// </para>
+        /// </exception>
+        public SemanticVersion Next(int line, MonotonicChange change)
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Returns the next version number when a specified change is
+        /// made to a given line of compatibility.
+        /// </para>
+        /// </summary>
+        /// <param name="line">
+        /// The line of compatibility to which the change is being
+        /// made.
+        /// </param>
+        /// <param name="change">
+        /// The type of change being made to <paramref name="line"/>.
+        /// </param>
+        /// <param name="metadata">
+        /// The metadata to be included with the new version.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// The next version number produced when the specified change
+        /// is made to the specified line of compatibility.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Compatible"/>, the release number
+        /// is incremented but the compatibility number remains the same.
+        /// </para>
+        /// <para>
+        /// If <paramref name="change"/> is equal to
+        /// <see cref="MonotonicChange.Breaking"/>, both the release and
+        /// compatibility numbers are incremented.
+        /// </para>
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para>
+        /// <paramref name="line"/> is negative.
+        /// </para>
+        /// <para>
+        /// <paramref name="line"/> is not a current line of compatibility.
+        /// </para>
+        /// <para>
+        /// <paramref name="change"/> is not a recognised type of change.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="metadata"/> or an item therein is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One or more items within <paramref name="metadata"/> is not a
+        /// valid metadata string.
+        /// </exception>
+        public SemanticVersion Next(
+            int line,
+            MonotonicChange change,
+            IEnumerable<string> metadata
+            )
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Returns a <see cref="MonotonicVersioner"/> with an identical
+        /// chronology, but which can advance its versions separately.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// A <see cref="MonotonicVersioner"/> with an identical chronology
+        /// up to the moment this method was called, but which is able
+        /// to separately advance its version numbers.
+        /// </returns>
+        public MonotonicVersioner Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+
+        /// <summary>
+        /// <para>
+        /// The chronologically-latest version number in this versioning
+        /// sequence.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The chronologically-latest version is the version with the
+        /// greatest value as its release component, regardless of the
+        /// line of compatibility.
+        /// </para>
+        /// </remarks>
+        public SemanticVersion Latest
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+        /// <summary>
+        /// <para>
+        /// The latest versions in each line of compatibility, where the
+        /// key is the line of compatibility.
+        /// </para>
+        /// </summary>
+        public IReadOnlyDictionary<int, SemanticVersion> LatestVersions
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// <para>
+        /// The latest compatibility number.
+        /// </para>
+        /// </summary>
+        public int Compatibility
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+        /// <summary>
+        /// <para>
+        /// The current release number.
+        /// </para>
+        /// </summary>
+        public int Release
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// <para>
+        /// The monotonic versions this instance has produced, in 
+        /// chronological order.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For monotonic versions, chronological order means that the
+        /// versions are ordered by ascending release number.
+        /// </para>
+        /// </remarks>
+        public IEnumerable<SemanticVersion> Chronology
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -105,6 +105,102 @@ namespace McSherry.SemanticVersioning.Monotonic
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// <para>
+        /// Creates a new <see cref="MonotonicVersioner"/> instance.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Compatibility"/> number sequence produced
+        /// by an instance which was created using this constructor
+        /// starts at one. If a zero-based sequence is required, use
+        /// <see cref="MonotonicVersioner(bool)"/>.
+        /// </remarks>
+        public MonotonicVersioner()
+            : this(startAtOne: true)
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Creates a new <see cref="MonotonicVersioner"/> instance.
+        /// Refer to remarks for differences from 
+        /// <see cref="MonotonicVersioner()"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="startAtOne">
+        /// If true, the produced <see cref="Compatibility"/> number
+        /// sequence starts at one. If false, zero.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// The Monotonic Versioning Manifesto 1.2 does not specify
+        /// whether the <see cref="Compatibility"/> component of versions 
+        /// are to start at one or zero. It is assumed that either is valid 
+        /// as neither is specifically recommended nor prohibited.
+        /// </para>
+        /// <para>
+        /// If the <see cref="Compatibility"/> components are to start at
+        /// one, <see cref="MonotonicVersioner()"/> may be used.
+        /// </para>
+        /// </remarks>
+        public MonotonicVersioner(bool startAtOne)
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Creates a new <see cref="MonotonicVersioner"/> with the
+        /// specified version number history.
+        /// </para>
+        /// </summary>
+        /// <param name="chronology">
+        /// A collection of version numbers providing the version
+        /// history to use for this instance.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="chronology"/> or an item thereof is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="chronology"/> contains a version which is
+        /// not a valid monotonic version.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <para>
+        /// <paramref name="chronology"/> provides an incomplete
+        /// version history. The chronology may:
+        /// </para>
+        /// <list type="bullet">
+        ///     <item>
+        ///     <description>
+        ///     Not provide a contiguous sequence of <see cref="Compatibility"/>
+        ///     numbers;
+        ///     </description>
+        ///     </item>
+        ///     <item>
+        ///     <description>
+        ///     Not provide a contiguous sequence of <see cref="Release"/>
+        ///     numbers;
+        ///     </description>
+        ///     </item>
+        ///     <item>
+        ///     <description>
+        ///     Not contain a <see cref="Compatibility"/> starting at either
+        ///     zero or one; or
+        ///     </description>
+        ///     </item>
+        ///     <item>
+        ///     <description>
+        ///     Be empty.
+        ///     </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        public MonotonicVersioner(IEnumerable<SemanticVersion> chronology)
+            : this()
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// <para>
@@ -342,7 +438,8 @@ namespace McSherry.SemanticVersioning.Monotonic
 
         /// <summary>
         /// <para>
-        /// The latest compatibility number.
+        /// The highest compatibility number. This component indicates which
+        /// releases are compatible with each other.
         /// </para>
         /// </summary>
         public int Compatibility
@@ -354,7 +451,8 @@ namespace McSherry.SemanticVersioning.Monotonic
         }
         /// <summary>
         /// <para>
-        /// The current release number.
+        /// The current release number. This component indicates when a release
+        /// was made relative to other releases.
         /// </para>
         /// </summary>
         public int Release

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -437,7 +437,7 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// <returns>
         /// <para>
         /// The next version number produced when the specified change
-        /// is made to the latest version.
+        /// is made to the latest version, with the specified metadata.
         /// </para>
         /// <para>
         /// If <paramref name="change"/> is equal to
@@ -515,7 +515,8 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// <summary>
         /// <para>
         /// Returns the next version number when a specified change is
-        /// made to a given line of compatibility.
+        /// made to a given line of compatibility with the specified
+        /// metadata.
         /// </para>
         /// </summary>
         /// <param name="line">

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -158,6 +158,10 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// A collection of version numbers providing the version
         /// history to use for this instance.
         /// </param>
+        /// <remarks>
+        /// <paramref name="chronology"/> is not required to be
+        /// in order.
+        /// </remarks>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="chronology"/> or an item thereof is null.
         /// </exception>

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -123,9 +123,8 @@ namespace McSherry.SemanticVersioning.Monotonic
         }
         /// <summary>
         /// <para>
-        /// Creates a new <see cref="MonotonicVersioner"/> instance.
-        /// Refer to remarks for differences from 
-        /// <see cref="MonotonicVersioner()"/>.
+        /// Creates a new <see cref="MonotonicVersioner"/> instance
+        /// with the specified initial compatibility line.
         /// </para>
         /// </summary>
         /// <param name="startAtOne">
@@ -145,6 +144,46 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// </para>
         /// </remarks>
         public MonotonicVersioner(bool startAtOne)
+            : this(startAtOne, Enumerable.Empty<string>())
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Creates a new <see cref="MonotonicVersioner"/> instance with
+        /// the specified initial compatibility line and metadata.
+        /// </para>
+        /// </summary>
+        /// <param name="startAtOne">
+        /// If true, the produced <see cref="Compatibility"/> number
+        /// sequence starts at one. If false, zero.
+        /// </param>
+        /// <param name="metadata">
+        /// Any metadata items to be included as part of the
+        /// initial version number.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// The Monotonic Versioning Manifesto 1.2 does not specify
+        /// whether the <see cref="Compatibility"/> component of versions 
+        /// are to start at one or zero. It is assumed that either is valid 
+        /// as neither is specifically recommended nor prohibited.
+        /// </para>
+        /// <para>
+        /// If the <see cref="Compatibility"/> components are to start at
+        /// one, <see cref="MonotonicVersioner()"/> may be used.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="metadata"/> or an item thereof is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One or more of the items in <paramref name="metadata"/> is not
+        /// a valid metadata item.
+        /// </exception>
+        public MonotonicVersioner(
+            bool startAtOne, IEnumerable<string> metadata
+            )
         {
             throw new NotImplementedException();
         }
@@ -320,11 +359,11 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// <paramref name="line"/> is negative.
         /// </para>
         /// <para>
-        /// <paramref name="line"/> is not a current line of compatibility.
-        /// </para>
-        /// <para>
         /// <paramref name="change"/> is not a recognised type of change.
         /// </para>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="line"/> is not a current line of compatibility.
         /// </exception>
         public SemanticVersion Next(int line, MonotonicChange change)
         {
@@ -367,9 +406,6 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// <paramref name="line"/> is negative.
         /// </para>
         /// <para>
-        /// <paramref name="line"/> is not a current line of compatibility.
-        /// </para>
-        /// <para>
         /// <paramref name="change"/> is not a recognised type of change.
         /// </para>
         /// </exception>
@@ -377,8 +413,13 @@ namespace McSherry.SemanticVersioning.Monotonic
         /// <paramref name="metadata"/> or an item therein is null.
         /// </exception>
         /// <exception cref="ArgumentException">
+        /// <para>
         /// One or more items within <paramref name="metadata"/> is not a
         /// valid metadata string.
+        /// </para>
+        /// <para>
+        /// <paramref name="line"/> is not a current line of compatibility.
+        /// </para>
         /// </exception>
         public SemanticVersion Next(
             int line,

--- a/libSemVer.NET/Monotonic/MonotonicVersioner.cs
+++ b/libSemVer.NET/Monotonic/MonotonicVersioner.cs
@@ -29,6 +29,7 @@ namespace McSherry.SemanticVersioning.Monotonic
     /// software package.
     /// </para>
     /// </summary>
+    [CLSCompliant(true)]
     public enum MonotonicChange
     {
         /// <summary>

--- a/libSemVer.NET/SemanticVersion.Formatting.cs
+++ b/libSemVer.NET/SemanticVersion.Formatting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 Liam McSherry
+﻿// Copyright (c) 2015-16 Liam McSherry
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -79,6 +79,21 @@ namespace McSherry.SemanticVersioning
         /// </para>
         /// </remarks>
         public static string PrefixedConcise    => "c";
+
+        /// <summary>
+        /// <para>
+        /// The format used for monotonic version strings. Aliases
+        /// <see cref="Concise"/>.
+        /// </para>
+        /// </summary>
+        public static string Monotonic          => Concise;
+        /// <summary>
+        /// <para>
+        /// The format used for monotonic version strings, prefixed
+        /// with a letter "v". Aliases <see cref="PrefixedConcise"/>.
+        /// </para>
+        /// </summary>
+        public static string PrefixedMonotonic  => PrefixedConcise;
     }
 
     // Documentation/attributes/interfaces/etc are in the main


### PR DESCRIPTION
## What is Monotonic Versioning?

[**Monotonic Versioning**][1] is a versioning specification that's mostly compatible with Semantic Versioning. Unlike traditional version numbers, monotonic versions have two completely unlinked components instead of major-minor (or major-minor-patch): the _compatibility_ component, which tells you which versions are backwards-compatible with each other; and the _release_ component, which gives you an indication of when a version was released relative to another.

```
1.7
┬ ┬
│ └────────────── Release Number:
│                     Always increases from zero, does not
│                     reset. Indicates when one release was
│                     made relative to another.
│
└────────── Compatibility Number:
                Indicates which releases are compatible with
                each other. A greater release number with the
                same compatibility number means that release is
                backwards-compatible.
```

A comparison is given below.

 # | Change         | Monotonic Version | Semantic Version |
:-:|:--------------:|:-----------------:|:----------------:|
 1 | &mdash;        | 1.0               | 1.0.0            |
 2 | Compatible     | 1.1               | 1.1.0            |
 3 | Compatible     | 1.2               | 1.2.0            |
 4 | Breaking       | 2.3               | 2.0.0            |
 5 | Compatible (v1)| 1.4               | 1.3.0            |
 6 | Compatible (v2)| 2.5               | 2.1.0            |

As implied by the name, the monotonic version numbers never get decrease.

[1]: http://web.archive.org/web/20160712103616/http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/

## How does this add support for it?

These changes add the `MonotonicVersioner` class (among others). Each instance of this class maintains a version history, and has a `Next(...)` method which can be used to create a new version in the sequence.

As the format of Monotonic Versions is compatible with Semantic Versions, all methods currently provided for parsing Semantic Versions can be used to parse Monotonic Versions. An `IsMonotonic` extension method is provided to validate Semantic Versions as Monotonic Versions and, due to slightly different comparison rules, a `MonotonicComparer` (implements `IComparer<SemanticVersion>`) is also provided, although it's only needed when the versions being compared have metadata.

Everything new is under the `McSherry.SemanticVersioning.Monotonic` namespace.