### PR TITLE
Add support for greedy parsing

### DIFF
--- a/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
@@ -791,6 +791,132 @@ namespace McSherry.SemanticVersioning
 
         /// <summary>
         /// <para>
+        /// Tests that greedy parsing works as expected.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void Parse_Greedy()
+        {
+            // The parser, when in "greedy" mode, will attempt to parse as much
+            // as it can. When it encounters an error, it will take whatever it
+            // has and try to make that into a valid version.
+            //
+            // If a valid version can be made, it's returned. Otherwise, whatever
+            // error encountered is allowed to propagate upwards.
+
+
+            // Tests that should produce valid output in greedy mode
+            const ParseMode greedy = ParseMode.Greedy;
+            const ParseMode prefix = ParseMode.AllowPrefix;
+            const ParseMode patch  = ParseMode.OptionalPatch;
+
+            (string VID, string Input, SemanticVersion Output, ParseMode Mode)[] vectors1 =
+            {
+                ("V1.1",    "1",            (SemanticVersion)"1.0.0",       greedy),
+                ("V1.2",    "1.",           (SemanticVersion)"1.0.0",       greedy),
+                ("V1.3",    "1    ",        (SemanticVersion)"1.0.0",       greedy),
+                ("V1.4",    "1jhgw",        (SemanticVersion)"1.0.0",       greedy),
+                ("V1.5",    "1.5",          (SemanticVersion)"1.5.0",       greedy),
+                ("V1.6",    "1.5oiugbew",   (SemanticVersion)"1.5.0",       greedy),
+                ("V1.7",    "1.5-",         (SemanticVersion)"1.5.0",       greedy),
+                ("V1.8",    "1.5-abc",      (SemanticVersion)"1.5.0",       greedy),
+                ("V1.9",    "1.5-abc.",     (SemanticVersion)"1.5.0-abc",   greedy | patch),
+                ("V1.10",   "1.5-abc!!£R",  (SemanticVersion)"1.5.0-abc",   greedy | patch),
+                ("V1.11",   "1.5+",         (SemanticVersion)"1.5.0",       greedy),
+                ("V1.12",   "1.5+abc",      (SemanticVersion)"1.5.0",       greedy),
+                ("V1.13",   "1.5+abc.",     (SemanticVersion)"1.5.0+abc",   greedy | patch),
+                ("V1.14",   "1.5+abc!%$£",  (SemanticVersion)"1.5.0+abc",   greedy | patch),
+                ("V1.15",   "1.5.",         (SemanticVersion)"1.5.0",       greedy),
+                ("V1.16",   "1.5.0-",       (SemanticVersion)"1.5.0",       greedy),
+                ("V1.17",   "1.5.0-abc.",   (SemanticVersion)"1.5.0-abc",   greedy),
+                ("V1.18",   "1.5.0-abc&^(", (SemanticVersion)"1.5.0-abc",   greedy),
+                ("V1.19",   "1.5.0+",       (SemanticVersion)"1.5.0",       greedy),
+                ("V1.20",   "1.5.0+abc.",   (SemanticVersion)"1.5.0+abc",   greedy),
+                ("V1.21",   "1.5.0+ab&($%", (SemanticVersion)"1.5.0+ab",    greedy),
+                ("V1.22",   "v1",           (SemanticVersion)"1.0.0",       greedy | prefix),
+                ("V1.23",   "1..1",         (SemanticVersion)"1.0.0",       greedy),
+                ("V1.24",   "1.1.-abc",     (SemanticVersion)"1.1.0",       greedy),
+                ("V1.25",   "1.5.0-ab..cd", (SemanticVersion)"1.5.0-ab",    greedy),
+                ("V1.26",   "1.5.0+ab..cd", (SemanticVersion)"1.5.0+ab",    greedy),
+                ("V1.27",   "1.5-ab..cd",   (SemanticVersion)"1.5.0-ab",    greedy | patch),
+                ("V1.28",   "1.5+ab..cd",   (SemanticVersion)"1.5.0+ab",    greedy | patch),
+                ("V1.29",   "1.05",         (SemanticVersion)"1.0.0",       greedy),
+                ("V1.30",   "1.05.0",       (SemanticVersion)"1.0.0",       greedy),
+                ("V1.31",   "1.1.05",       (SemanticVersion)"1.1.0",       greedy),
+            };
+
+            foreach (var vector in vectors1)
+            {
+                SemanticVersion sv = null;
+
+                try
+                {
+                    sv = SemanticVersion.Parse(vector.Input, vector.Mode);
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Parse failure, vector {vector.VID}:\n\n{ex}");
+                }
+
+                Assert.AreEqual(
+                    expected:   vector.Output,
+                    actual:     sv,
+                    message:    $"Failure: vector {vector.VID}"
+                    );
+            }
+
+
+            // Tests that should provoke a [FormatException] in greedy mode with
+            // no other flags being specified
+            (string VID, string Input)[] vectors2 =
+            {
+                ("V2.1",    "v1"),
+                ("V2.2",    "v1."),
+                ("V2.3",    "v1.5"),
+                ("V2.4",    "v1.5"),
+                ("V2.5",    "v1.5.0"),
+                ("V2.6",    "v1.5.0-"),
+                ("V2.7",    "i1"),
+                ("V2.8",    "i1."),
+                ("V2.9",    "i1.5"),
+                ("V2.10",   "i1.5."),
+                ("V2.11",   "i1.5.0"),
+                ("V2.12",   "i1.5.0-"),
+                ("V2.13",   ".1.0"),
+                ("V2.14",   "01"),
+                ("V2.15",   "01.0"),
+                ("V2.16",   "01.0.0"),
+            };
+
+            foreach (var vector in vectors2)
+            {
+                Assert.ThrowsException<FormatException>(
+                    action:     () => SemanticVersion.Parse(vector.Input, greedy),
+                    message:    $"Failure: vector {vector.VID}"
+                    );
+            }
+
+
+            // Tests that should provoke an [OverflowException]
+            (string VID, string Input)[] vectors3 =
+            {
+                ("V3.1",    "2147483648"),
+                ("V3.2",    "10000000000"),
+                ("V3.3",    "1.2147483648"),
+                ("V3.4",    "1.1.2147483648"),
+            };
+
+            foreach (var vector in vectors3)
+            {
+                Assert.ThrowsException<OverflowException>(
+                    action:     () => SemanticVersion.Parse(vector.Input, greedy),
+                    message:    $"Failure: vector {vector.VID}"
+                    );
+            }
+        }
+
+        /// <summary>
+        /// <para>
         /// Tests that parsing <see cref="SemanticVersion"/> strings works
         /// as expected when the parser is given an invalid string.
         /// </para>

--- a/McSherry.SemanticVersioning/Helper.cs
+++ b/McSherry.SemanticVersioning/Helper.cs
@@ -32,16 +32,26 @@ namespace McSherry.SemanticVersioning
     /// </summary>
     internal static class Helper
     {
-        private static readonly Regex _metaRegex;
-
-        static Helper()
+        /// <summary>
+        /// <para>
+        /// Determines whether a specified character is valid in a metadata item
+        /// or pre-release identifier.
+        /// </para>
+        /// </summary>
+        /// <param name="c">
+        /// The character to check.
+        /// </param>
+        /// <returns>
+        /// True if <paramref name="c"/> is valid in a metadata item or pre-release
+        /// identifier, false if otherwise.
+        /// </returns>
+        public static bool IsMetadataChar(char c)
         {
-            // We're going to save ourselves some trouble and just use a
-            // regular expression to check each individual build metadata
-            // item.
-            _metaRegex = new Regex("^[0-9A-Za-z-]+$");
+            return (c == 0x2D) ||               // '-'
+                   (c >= 0x30 && c <= 0x39) ||  // 0-9
+                   (c >= 0x41 && c <= 0x5A) ||  // A-Z
+                   (c >= 0x61 && c <= 0x7A);    // a-z
         }
-
         /// <summary>
         /// <para>
         /// Checks whether a provided <see cref="string"/> is a valid
@@ -90,17 +100,18 @@ namespace McSherry.SemanticVersioning
         /// </returns>
         public static bool IsValidMetadata(string metadata)
         {
-            // Metadata items cannot be empty, and cannot contain
-            // whitespace.
-            if (String.IsNullOrWhiteSpace(metadata))
+            // An empty or null string cannot be valid.
+            if (metadata == null || metadata.Length == 0)
                 return false;
 
-            // A metadata item may only contain characters that are
-            // alphanumeric or the hyphen character.
-            if (!_metaRegex.IsMatch(metadata))
-                return false;
+            // LINQ's [All] and [Any] aren't available in .NET Core 1.0 or
+            // .NET Standard 1.0.
+            foreach (var c in metadata)
+            {
+                if (!IsMetadataChar(c))
+                    return false;
+            }
 
-            // It's passed the tests, so it's a valid metadata item.
             return true;
         }
 

--- a/McSherry.SemanticVersioning/Internals/Shims/ReadOnlyListShim.cs
+++ b/McSherry.SemanticVersioning/Internals/Shims/ReadOnlyListShim.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 
 namespace McSherry.SemanticVersioning.Internals.Shims
 {
-#if USE_SHIMS
+#if COMMON_SHIMS
     /// <summary>
     /// <para>
     /// Provides methods for working with read-only lists under .NET Standard.

--- a/McSherry.SemanticVersioning/Internals/Shims/SerializableShim.cs
+++ b/McSherry.SemanticVersioning/Internals/Shims/SerializableShim.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace McSherry.SemanticVersioning.Internals.Shims
 {
-#if USE_SHIMS
+#if COMMON_SHIMS
     /// <summary>
     /// <para>
     /// A shim to allow .NET Standard configurations to build.

--- a/McSherry.SemanticVersioning/Internals/Shims/StringShim.cs
+++ b/McSherry.SemanticVersioning/Internals/Shims/StringShim.cs
@@ -22,7 +22,7 @@ using System.Collections.Generic;
 
 namespace McSherry.SemanticVersioning.Internals.Shims
 {
-#if USE_SHIMS
+#if COMMON_SHIMS
     /// <summary>
     /// <para>
     /// Provides shims that make <see cref="string"/> work as expected.

--- a/McSherry.SemanticVersioning/McSherry.SemanticVersioning.csproj
+++ b/McSherry.SemanticVersioning/McSherry.SemanticVersioning.csproj
@@ -49,7 +49,7 @@
             by .NET Standard, and defining this constant compiles in
             replacements that allow the library to work.
         -->
-        <DefineConstants>USE_SHIMS</DefineConstants>
+        <DefineConstants>COMMON_SHIMS</DefineConstants>
     </PropertyGroup>
     
     <!-- .NET Core 1.0 -->
@@ -57,6 +57,6 @@
     
     </ItemGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0'">
-        <DefineConstants>USE_SHIMS</DefineConstants>
+        <DefineConstants>COMMON_SHIMS</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
@@ -527,12 +527,6 @@ namespace McSherry.SemanticVersioning
         [Serializable]
         internal class ParseMetadata
         {
-            public static ParseMetadata Default { get; } = new ParseMetadata(
-                major: ComponentState.Present,
-                minor: ComponentState.Present,
-                patch: ComponentState.Present
-                );
-
             public ParseMetadata(
                 ComponentState major, ComponentState minor, ComponentState patch)
             {
@@ -599,19 +593,6 @@ namespace McSherry.SemanticVersioning
             public ComponentState PatchState
             {
                 get;
-            }
-
-            /// <summary>
-            /// <para>
-            /// Determines whether the instance contains only default values.
-            /// </para>
-            /// </summary>
-            /// <returns></returns>
-            public bool IsDefault()
-            {
-                return this.MinorState == Default.MinorState &&
-                       this.PatchState == Default.PatchState
-                       ;
             }
         }
 

--- a/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
@@ -64,6 +64,23 @@ namespace McSherry.SemanticVersioning
         /// </para>
         /// </summary>
         OptionalPatch   = 1 << 1,
+        /// <summary>
+        /// <para>
+        /// The parser will, if it encounters an error, attempt to return a valid
+        /// <see cref="SemanticVersion"/> instance instead of an error.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The effect of other <see cref="ParseMode"/>s must be considered
+        /// when specifying <see cref="Greedy"/>. For example, <c>1.2</c> will
+        /// produce the expected result with both <see cref="Greedy"/> and
+        /// <see cref="OptionalPatch"/>, but <c>v1.2</c> with <see cref="Greedy"/>
+        /// will result in failure unless <see cref="AllowPrefix"/> is also
+        /// specified.
+        /// </para>
+        /// </remarks>
+        Greedy          = 1 << 2,
     }
 
     // Documentation/attributes/interfaces/etc are in the main

--- a/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
@@ -46,10 +46,10 @@ namespace McSherry.SemanticVersioning
         /// <summary>
         /// <para>
         /// The opposite of <see cref="Strict"/>, with all parser flags
-        /// set.
+        /// set but <see cref="Greedy"/>.
         /// </para>
         /// </summary>
-        Lenient         = ~0,
+        Lenient         = ~0 ^ Greedy,
 
         /// <summary>
         /// <para>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ semantic versions.
 ## Features
 
 - Full support for Semantic Versioning ([2.0.0][7]) and Monotonic Versioning ([1.2][8])
-- Practically full support for [`node-semver`][9] version ranges (up to v6.0.0)[**\***][10]
+- Practically full support[**\***][10] for [`node-semver`][9] version ranges (up to v6.0.0)
+- Provides parsing, comparison, and formatting
 - Flexible and configurable parsing to suit nearly any application
 - Targets .NET Framework 4.5 and 4.6, .NET Core 1.0, and .NET Standard 1.0
 

--- a/docs/McSherry.SemanticVersioning/ParseMode.md
+++ b/docs/McSherry.SemanticVersioning/ParseMode.md
@@ -24,7 +24,7 @@ may be configured to use.
   specification compliance.
   
 - **`Lenient`**  
-  The opposite of `Strict`, with all parser flags set.
+  The opposite of `Strict`, with all parser flags set but `Greedy`.
   
 - **`AllowPrefix`**  
   The parser will accept a version prefixed with `v` or `V`.
@@ -33,4 +33,12 @@ may be configured to use.
   The parser will accept versions with the [SemanticVersion.Patch][3]
   version component omitted.
   
+- **`Greedy`**  
+  The parser will, if it encounters an error, attempt to return a
+  valid [SemanticVersion][2] instance instead of an error.
+  
+  **Remarks:** The effect of other `ParseMode`s must be considered when
+  specifying `Greedy`. For example, `1.2` will produce the expected result
+  with both `Greedy` and `OptionalPatch`, but `v1.2` with `Greedy` will
+  result in failure unless `AllowPrefix` is also specified.
 [3]: ./SemanticVersion/Patch.md

--- a/docs/McSherry.SemanticVersioning/SemanticVersion/Parse(String,ParseMode,IEnumerator(T)).md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersion/Parse(String,ParseMode,IEnumerator(T)).md
@@ -1,0 +1,81 @@
+# `SemanticVersion.Parse(String, ParseMode, IEnumerator(char))` method
+
+```c#
+public static SemanticVersion Parse(
+    string version,
+    ParseMode mode,
+    out IEnumerator<char> enumerator
+)
+```
+
+**Namespace:** [`McSherry.SemanticVersioning`][1]  
+**Minimum version:** 1.3.0
+
+[1]: ../
+
+Converts a version string to a [SemanticVersion][2], taking
+into account a set of flags.
+
+[2]: ./
+
+
+### Parameters
+
+- **`version`**  
+  **Type:** `System.String`  
+  The version string to be converted to a [SemanticVersion][2].
+- **`mode`**  
+  **Type:** [`McSherry.SemanticVersioning.ParseMode`][3]  
+  A set of flags to augment how the version string is parsed.
+- **`enumerator`**  
+  **Type:** `System.Collections.Generic.IEnumerator<char>`  
+  An enumerator over `version`, positioned after the last character
+  of the [SemanticVersion][2] parsed from `version`, or null if the parser
+  reached the end of the string.
+
+
+
+[3]: ../ParseMode.md
+
+
+### Return Value
+
+**Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]
+
+A [SemanticVersion][2] equivalent to the provided version string.
+
+
+## Exceptions
+
+- **`System.ArgumentNullException`**  
+  Thrown when _`version`_ is null or empty.
+- **`System.ArgumentException`**  
+  Thrown when a component in the version string was expected but
+  not found (for example, a missing minor or patch version).
+- **`System.FormatException`**  
+  Thrown when an invalid character or character sequence is
+  encountered.
+- **`System.OverflowException`**  
+  Thrown when an attempt to convert the major, minor, or patch
+  version into a `System.Int32` resulted in an overflow.
+
+## Remarks
+
+The parameter `enumerator` exposes the enumerator used internally
+by the parser to walk `version`. Its intended use is where
+[ParseMode.Greedy][3] is specified in `mode`, where it enables the caller to
+implement further parsing (for example, if the caller has a meaningful
+way to convert a `System.Version` to a [SemanticVersion][2]).
+
+On success, the value of `enumerator` depends on whether the end of
+`version` was reached. If it was, `enumerator` will be null. Otherwise, it
+will have a value and its `IEnumerator<T>.Current` property will be
+positioned after the last character of `version` that the parser processed.
+If [ParseMode.Greedy][3] is specified and `1.0.0.0` is provided as an input,
+the returned enumerator will be on the third `.`.
+
+As part of the processing before parsing, leading and trailing whitespace
+is stripped. Anything returned in `enumerator` will, accordingly, not include
+leading or trailing whitespace.
+
+On failure, the value of `enumerator` is undefined.

--- a/docs/McSherry.SemanticVersioning/SemanticVersion/README.md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersion/README.md
@@ -113,20 +113,28 @@ inherited.
 
 ## Static Methods
 
+- [**Parse(String, ParseMode, out IEnumerator(char))**][A23]  
+  Converts a string to a [SemanticVersion][7], taking into account a set
+  of flags.
 - **[Parse(String, ParseMode)][23]**  
   Converts a version string to a [SemanticVersion][7], taking into account
   a set of flags.
 - **[Parse(String)][24]**  
   Converts a version string to a [SemanticVersion][7], only accepting the
   format given in the [Semantic Versioning specification][2].
+- [**TryParse(String, ParseMode, out SemanticVersion, out IEnumerator(char))**][24A]  
+  Attempts to convert a version string to a [SemanticVersion][7], taking
+  into account a set of flags.
 - **[TryParse(String, ParseMode, out SemanticVersion)][25]**  
   Attempts to convert a version string to a [SemanticVersion][7], taking
   into account a set of flags.
 - **[TryParse(String, out SemanticVersion)][26]**  
   Attempts to convert a version string to a [SemanticVersion][7].
 
+[A23]: ./Parse(String,ParseMode,IEnumerator(T)).md
 [23]: ./Parse(String,ParseMode).md
 [24]: ./Parse(String).md
+[24A]: ./TryParse(String,ParseMode,SemanticVersion,IEnumerator(T)).md
 [25]: ./TryParse(String,ParseMode,SemanticVersion).md
 [26]: ./TryParse(String,SemanticVersion).md
 

--- a/docs/McSherry.SemanticVersioning/SemanticVersion/TryParse(String,ParseMode,SemanticVersion,IEnumerator(T)).md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersion/TryParse(String,ParseMode,SemanticVersion,IEnumerator(T)).md
@@ -1,0 +1,54 @@
+# `SemanticVersion.TryParse(String, ParseMode, out SemanticVersion, IEnumerator(char))` method
+
+```c#
+public static bool TryParse(
+    string version,
+    ParseMode mode,
+    out SemanticVersion semver,
+    out IEnumerator<char> enumerator
+)
+```
+
+**Namespace:** [`McSherry.SemanticVersioning`][1]  
+**Minimum version:** 1.3.0
+
+[1]: ../
+
+Attempts to convert a version string to a [SemanticVersion][2], taking
+into account a set of flags.
+
+[2]: ./
+
+
+### Parameters
+
+- **`version`**  
+  **Type:** `System.String`  
+  The version string to be converted to a [SemanticVersion][2].
+- **`mode`**  
+  **Type:** [`McSherry.SemanticVersioning.ParseMode`][3]  
+  A set of flags that augment how the version string is parsed.
+- **`semver`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+  When the method returns, this parameter is either set to the created
+  [SemanticVersion][2] (if parsing was successful), or is given an
+  undefined value (if parsing was unsuccessful).
+- **`enumerator`**  
+  **Type:** `System.Collections.Generic.IEnumerator<char>`  
+  On success, either null (if the parser reached the end of `version`) or
+  an IEnumerator\<char\> positioned after the last character of the
+  [SemanticVersion][2] parsed from `version`. On failure, undefined.
+[3]: ../ParseMode.md
+
+
+### Return Value
+
+**Type:** `System.Boolean`
+
+True if parsing succeeded, false if otherwise.
+
+## Remarks
+
+For information about `enumerator`, see the remarks for [Parse(String, ParseMode, out IEnumerator(char))][4].
+
+[4]: ./Parse(String,ParseMode,IEnumerator(T)).md


### PR DESCRIPTION
_Relevant issue: #12_

### What is "greedy" parsing?

When configured to parse greedily, the parser will stop at the first error it encounters and attempt to construct a `SemanticVersion` instance from what it has already collected. It is "greedy" in the sense that it takes as much as it can, which means it will accept version strings that would not normally be accepted.

### Why would I use this?

You might use greedy parsing if you have a customised way of specifying versions, or if you store versions with other information that it can't easily be separated from. To aid this use case, this pull also adds overloads of `SemanticVersion.Parse` and `TryParse` that expose an `IEnumerator<char>` that stops on the next character after the version string.

The addition of greedy parsing was inspired by #7. A `System.Version` cannot be converted to a `SemanticVersion` in a way that works for everyone&mdash;the two are not compatible, not least because the former has four components (`Major.Minor.Build.Revision`) and latter three (`Major.Minor.Patch`). 

Configured to parse greedily, feeding `1.0.0.0` into the parser will produce a `SemanticVersion` with value `1.0.0` and, with the overloads of `Parse` and `TryParse` this pull adds, an `IEnumerator<char>` sitting on the third `.`. A caller could then parse the remaining component and use this and the returned version, perhaps creating a new `SemanticVersion` instance with build metadata.

### Can you give me some examples?

These are examples of greedy parsing behaviour from the tests for the functionality.

```
           "1" → 1.0.0
       "1jhgw" → 1.0.0
 "1.5-abc!!£R" → 1.5.0-abc
  "1.5+ab..cd" → 1.5.0+ab
        "1.05" → 1.0.0
      "1.1.05" → 1.1.0
          "v1" → FormatException (except with AllowPrefix)
      "01.0.0" → FormatException
  "2147483648" → OverflowException
"1.2147483648" → OverflowException
```