### PR TITLE
Add support for custom format patterns

### DIFF
--- a/McSherry.SemanticVersioning.Benchmarking/SemanticVersionFormatBenchmarks.cs
+++ b/McSherry.SemanticVersioning.Benchmarking/SemanticVersionFormatBenchmarks.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2020 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet;
+using BenchmarkDotNet.Attributes;
+
+namespace McSherry.SemanticVersioning
+{
+    [MemoryDiagnoser]
+    public class SemanticVersionFormatBenchmarks
+    {
+        private readonly SemanticVersion SV = (SemanticVersion)"1.7.0-alpha.2+20150925.f8f2cb1a";
+
+        // Benchmarks the fast path general format specifier
+        [Benchmark(Baseline = true)]
+        public string Format_General() => SV.ToString();
+
+        // Benchmarks the equivalent of the general format specifier, but this
+        // time it causes the cusstom formatter to be used rather than the fast path.
+        [Benchmark]
+        public string Format_GeneralEquiv() => SV.ToString("M.m.pRRDD");
+    }
+}

--- a/McSherry.SemanticVersioning.Testing/McSherry.SemanticVersioning.Testing.csproj
+++ b/McSherry.SemanticVersioning.Testing/McSherry.SemanticVersioning.Testing.csproj
@@ -8,16 +8,13 @@
         <TargetFrameworks>
             net45;
             net46;
-            netcoreapp1.0;
-            netstandard1.0;
-            netstandard2.0
+            netcoreapp1.0
         </TargetFrameworks>
     </PropertyGroup>
     
     <ItemGroup>
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
         
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
         
@@ -26,9 +23,19 @@
         <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     </ItemGroup>
     
+    <!-- .NET Core -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.2.0" />
+    </ItemGroup>
+    
     <!-- .NET Framework -->
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' Or
-                               '$(TargetFramework)' == 'net46'">
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' ">
         <DefineConstants>NETFW</DefineConstants>
     </PropertyGroup>
+    
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' ">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.6.1" />
+    </ItemGroup>
 </Project>

--- a/McSherry.SemanticVersioning.Testing/McSherry.SemanticVersioning.Testing.csproj
+++ b/McSherry.SemanticVersioning.Testing/McSherry.SemanticVersioning.Testing.csproj
@@ -3,8 +3,8 @@
     <PropertyGroup>
         <AssemblyName>McSherry.SemanticVersioning.Testing</AssemblyName>
         <RootNamespace>McSherry.SemanticVersioning</RootNamespace>
-        <Copyright>2015-17 (c) Liam McSherry</Copyright>
-        
+        <Copyright>2015-20 (c) Liam McSherry</Copyright>
+            
         <TargetFrameworks>
             net45;
             net46;

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionFormatTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionFormatTests.cs
@@ -175,7 +175,7 @@ namespace McSherry.SemanticVersioning
             Assert.AreEqual(output, ((SemanticVersion)version).ToString("RR"));
         }
 
-        [DataRow(Str_AllComponents, "alpha-2")]
+        [DataRow(Str_AllComponents, "alpha.2")]
         [DataRow(Str_Prerelease, "rc.1")]
         [DataRow(Str_Metadata, "")]
         [DataRow(Str_Basic_NoPatch, "")]
@@ -283,7 +283,7 @@ namespace McSherry.SemanticVersioning
         [DataRow("{{Build Date:}} d0", "Build Date: 20150925")]
         [DataRow("Build Date: d0", "Build 20150925.f8f2cb1aate: 20150925")]
         [DataRow("M.m.p ({{Alpha Release}} r1)", "1.7.0 (Alpha Release 2)")]
-        [DataRow("M.m.p (Alpha Release r1)", "1.7.0 (Alpha alpha.2elease 2)")]
+        [DataRow("M.m.p (Alpha Release r1)", "1.7.0 (Al0ha alpha.2elease 2)")]
         [DataTestMethod]
         public void Custom_MultipleSpecifiers(string specifiers, string output)
         {

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionFormatTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionFormatTests.cs
@@ -1,0 +1,293 @@
+﻿// Copyright (c) 2020 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace McSherry.SemanticVersioning
+{
+    /// <summary>
+    /// Tests the methods provided for formatting a <see cref="SemanticVersion"/>
+    /// as a <see cref="string"/>.
+    /// </summary>
+    [TestClass]
+    public class SemanticVersionFormatTests
+    {
+        private const string Category = "Semantic Version Formatting";
+
+        // A version string with all components included
+        private const string Str_AllComponents = "1.7.0-alpha.2+20150925.f8f2cb1a";
+        // A version string with only pre-release identifiers
+        private const string Str_Prerelease = "2.0.1-rc.1";
+        // A version string with only metadata items
+        private const string Str_Metadata = "1.7.0+20150925.f8f2cb1a";
+        // A version string without any additional components, with a zero patch
+        private const string Str_Basic_NoPatch = "1.7.0";
+        // A version string without any additional components, with a non-zero patch
+        private const string Str_Basic_Patch = "2.0.1";
+
+
+        // ===== Standard Format Specifiers ===== //
+
+        public void StandardSpecifierValues()
+        {
+#pragma warning disable 618
+
+            Assert.AreEqual("G", SemanticVersionFormat.Default);
+            Assert.AreEqual("g", SemanticVersionFormat.PrefixedDefault);
+
+            Assert.AreEqual("C", SemanticVersionFormat.Concise);
+            Assert.AreEqual("c", SemanticVersionFormat.PrefixedConcise);
+            Assert.AreEqual("C", SemanticVersionFormat.Monotonic);
+            Assert.AreEqual("c", SemanticVersionFormat.PrefixedMonotonic);
+
+#pragma warning restore 618
+        }
+
+        [DataRow(Str_AllComponents, Str_AllComponents)]
+        [DataRow(Str_Prerelease, Str_Prerelease)]
+        [DataRow(Str_Metadata, Str_Metadata)]
+        [DataRow(Str_Basic_NoPatch, Str_Basic_NoPatch)]
+        [DataRow(Str_Basic_Patch, Str_Basic_Patch)]
+        [DataTestMethod]
+        public void Standard_General(string version, string output)
+        {
+            var v = (SemanticVersion)version;
+
+            Assert.AreEqual(output, v.ToString(), "Unspecified (default) format");
+            Assert.AreEqual(output, v.ToString("G"), "Explicit general specifier");
+            Assert.AreEqual(output, v.ToString(""), "Implicit general specifier, empty");
+            Assert.AreEqual(output, v.ToString(null), "Implicit general specifier, null");
+        }
+
+        [DataRow(Str_AllComponents, "v" + Str_AllComponents)]
+        [DataRow(Str_Prerelease, "v" + Str_Prerelease)]
+        [DataRow(Str_Metadata, "v" + Str_Metadata)]
+        [DataRow(Str_Basic_NoPatch, "v" + Str_Basic_NoPatch)]
+        [DataRow(Str_Basic_Patch, "v" + Str_Basic_Patch)]
+        [DataTestMethod]
+        public void Standard_PrefixedGeneral(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("g"));
+        }
+
+        [DataRow(Str_AllComponents, "1.7-alpha.2")]
+        [DataRow(Str_Prerelease, Str_Prerelease)]
+        [DataRow(Str_Metadata, "1.7")]
+        [DataRow(Str_Basic_NoPatch, "1.7")]
+        [DataRow(Str_Basic_Patch, "2.0.1")]
+        [DataTestMethod]
+        public void Standard_Concise(string version, string output)
+        {
+            var v = (SemanticVersion)version;
+
+            Assert.AreEqual(output, v.ToString("C"));
+        }
+
+        [DataRow(Str_AllComponents, "v1.7-alpha.2")]
+        [DataRow(Str_Prerelease, "v" + Str_Prerelease)]
+        [DataRow(Str_Metadata, "v1.7")]
+        [DataRow(Str_Basic_NoPatch, "v1.7")]
+        [DataRow(Str_Basic_Patch, "v2.0.1")]
+        [DataTestMethod]
+        public void Standard_PrefixedConcise(string version, string output)
+        {
+            var v = (SemanticVersion)version;
+
+            Assert.AreEqual(output, v.ToString("c"));
+        }
+
+
+        // ===== Custom Format Specifiers ===== //
+
+        [DataRow(Str_AllComponents, "1")]
+        [DataRow(Str_Prerelease, "2")]
+        [DataRow(Str_Metadata, "1")]
+        [DataRow(Str_Basic_NoPatch, "1")]
+        [DataRow(Str_Basic_Patch, "2")]
+        [DataTestMethod]
+        public void Custom_Major(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("M"));
+        }
+
+        [DataRow(Str_AllComponents, "7")]
+        [DataRow(Str_Prerelease, "0")]
+        [DataRow(Str_Metadata, "7")]
+        [DataRow(Str_Basic_NoPatch, "7")]
+        [DataRow(Str_Basic_Patch, "0")]
+        [DataTestMethod]
+        public void Custom_Minor(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("m"));
+        }
+
+        [DataRow(Str_AllComponents, "0")]
+        [DataRow(Str_Prerelease, "1")]
+        [DataRow(Str_Metadata, "0")]
+        [DataRow(Str_Basic_NoPatch, "0")]
+        [DataRow(Str_Basic_Patch, "1")]
+        [DataTestMethod]
+        public void Custom_Patch(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("p"));
+        }
+
+        [DataRow(Str_AllComponents, "")]
+        [DataRow(Str_Prerelease, ".1")]
+        [DataRow(Str_Metadata, "")]
+        [DataRow(Str_Basic_NoPatch, "")]
+        [DataRow(Str_Basic_Patch, ".1")]
+        [DataTestMethod]
+        public void Custom_OptionalPatch(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("pp"));
+        }
+
+        [DataRow(Str_AllComponents, "-alpha.2")]
+        [DataRow(Str_Prerelease, "-rc.1")]
+        [DataRow(Str_Metadata, "")]
+        [DataRow(Str_Basic_NoPatch, "")]
+        [DataRow(Str_Basic_Patch, "")]
+        [DataTestMethod]
+        public void Custom_PrefixedPrereleaseGroup(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("RR"));
+        }
+
+        [DataRow(Str_AllComponents, "alpha-2")]
+        [DataRow(Str_Prerelease, "rc.1")]
+        [DataRow(Str_Metadata, "")]
+        [DataRow(Str_Basic_NoPatch, "")]
+        [DataRow(Str_Basic_Patch, "")]
+        [DataTestMethod]
+        public void Custom_StandalonePrereleaseGroup(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("R"));
+        }
+
+        [DataRow(Str_AllComponents, 0, "alpha")]
+        [DataRow(Str_AllComponents, 1, "2")]
+        [DataRow(Str_Prerelease, 0, "rc")]
+        [DataRow(Str_Prerelease, 1, "1")]
+        [DataTestMethod]
+        public void Custom_IndexedPrereleaseID_Success(string version, int index, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString($"r{index}"));
+        }
+
+        [DataRow(Str_AllComponents, 2)]
+        [DataRow(Str_AllComponents, 3)]
+        [DataRow(Str_Prerelease, 2)]
+        [DataRow(Str_Prerelease, 3)]
+        [DataTestMethod]
+        public void Custom_IndexedPrereleaseID_Failure(string version, int index)
+        {
+            Assert.ThrowsException<FormatException>(
+                () => ((SemanticVersion)version).ToString($"r{index}")
+                );
+        }
+
+        [DataRow(Str_AllComponents)]
+        [DataRow(Str_Prerelease)]
+        [DataRow(Str_Metadata)]
+        [DataRow(Str_Basic_NoPatch)]
+        [DataRow(Str_Basic_Patch)]
+        [DataTestMethod]
+        public void Custom_Reserved_rr(string version)
+        {
+            Assert.ThrowsException<FormatException>(
+                () => ((SemanticVersion)version).ToString("rr")
+                );
+        }
+
+        [DataRow(Str_AllComponents, "20150925.f8f2cb1a")]
+        [DataRow(Str_Prerelease, "")]
+        [DataRow(Str_Metadata, "20150925.f8f2cb1a")]
+        [DataRow(Str_Basic_NoPatch, "")]
+        [DataRow(Str_Basic_Patch, "")]
+        [DataTestMethod]
+        public void Custom_StandaloneMetadataGroup(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("D"));
+        }
+
+        [DataRow(Str_AllComponents, "+20150925.f8f2cb1a")]
+        [DataRow(Str_Prerelease, "")]
+        [DataRow(Str_Metadata, "+20150925.f8f2cb1a")]
+        [DataRow(Str_Basic_NoPatch, "")]
+        [DataRow(Str_Basic_Patch, "")]
+        [DataTestMethod]
+        public void Custom_PrefixedMetadataGroup(string version, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString("DD"));
+        }
+
+        [DataRow(Str_AllComponents, 0, "20150925")]
+        [DataRow(Str_AllComponents, 1, "f8f2cb1a")]
+        [DataRow(Str_Metadata, 0, "20150925")]
+        [DataRow(Str_Metadata, 1, "f8f2cb1a")]
+        [DataTestMethod]
+        public void Custom_IndexedMetadata_Success(string version, int index, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)version).ToString($"d{index}"));
+        }
+
+        [DataRow(Str_AllComponents, 2)]
+        [DataRow(Str_AllComponents, 3)]
+        [DataRow(Str_Metadata, 2)]
+        [DataRow(Str_Metadata, 3)]
+        [DataTestMethod]
+        public void Custom_IndexedMetadata_Failure(string version, int index)
+        {
+            Assert.ThrowsException<FormatException>(
+                () => ((SemanticVersion)version).ToString($"d{index}")
+                );
+        }
+
+        [DataRow(Str_AllComponents)]
+        [DataRow(Str_Prerelease)]
+        [DataRow(Str_Metadata)]
+        [DataRow(Str_Basic_NoPatch)]
+        [DataRow(Str_Basic_Patch)]
+        [DataTestMethod]
+        public void Custom_Reserved_dd(string version)
+        {
+            Assert.ThrowsException<FormatException>(
+                () => ((SemanticVersion)version).ToString("dd")
+                );
+        }
+
+        [DataRow("M.m.pRRDD", Str_AllComponents)]
+        [DataRow("  c(m)", "  v1.7-alpha.2(7)")]
+        [DataRow("{{Build Date:}} d0", "Build Date: 20150925")]
+        [DataRow("Build Date: d0", "Build 20150925.f8f2cb1aate: 20150925")]
+        [DataRow("M.m.p ({{Alpha Release}} r1)", "1.7.0 (Alpha Release 2)")]
+        [DataRow("M.m.p (Alpha Release r1)", "1.7.0 (Alpha alpha.2elease 2)")]
+        [DataTestMethod]
+        public void Custom_MultipleSpecifiers(string specifiers, string output)
+        {
+            Assert.AreEqual(output, ((SemanticVersion)Str_AllComponents).ToString(specifiers));
+        }
+    }
+}

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionFormatTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionFormatTests.cs
@@ -284,10 +284,32 @@ namespace McSherry.SemanticVersioning
         [DataRow("Build Date: d0", "Build 20150925.f8f2cb1aate: 20150925")]
         [DataRow("M.m.p ({{Alpha Release}} r1)", "1.7.0 (Alpha Release 2)")]
         [DataRow("M.m.p (Alpha Release r1)", "1.7.0 (Al0ha alpha.2elease 2)")]
+        [DataRow("   G ", "   " + Str_AllComponents + " ")]
+        [DataRow("{ M.mpp }", "{ 1.7 }")]
+        [DataRow("{ M.mpp }}", "{ 1.7 }}")]
         [DataTestMethod]
         public void Custom_MultipleSpecifiers(string specifiers, string output)
         {
             Assert.AreEqual(output, ((SemanticVersion)Str_AllComponents).ToString(specifiers));
+        }
+
+        [DataRow("M.m {{unterminated verbatim")]
+        [DataTestMethod]
+        public void Custom_VerbatimErrors(string specifiers)
+        {
+            Assert.ThrowsException<FormatException>(
+                () => ((SemanticVersion)Str_AllComponents).ToString(specifiers)
+                );
+        }
+
+        [DataRow("r4294967296")]
+        [DataRow("d4294967296")]
+        [DataTestMethod]
+        public void Custom_IntParseOverflow(string specifiers)
+        {
+            Assert.ThrowsException<FormatException>(
+                () => ((SemanticVersion)Str_AllComponents).ToString(specifiers)
+                );
         }
     }
 }

--- a/McSherry.SemanticVersioning/SemanticVersion.Formatting.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Formatting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-16 Liam McSherry
+﻿// Copyright (c) 2015-20 Liam McSherry
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,8 @@ namespace McSherry.SemanticVersioning
     [CLSCompliant(true)]
     public static class SemanticVersionFormat
     {
+#pragma warning disable 618
+
         /// <summary>
         /// <para>
         /// The default way to format a semantic version.
@@ -54,6 +56,7 @@ namespace McSherry.SemanticVersioning
         /// see <see cref="Default"/>.
         /// </para>
         /// </remarks>
+        [Obsolete("Use custom format strings instead.", error: false)]
         public static string PrefixedDefault    => "g";
 
         /// <summary>
@@ -76,6 +79,7 @@ namespace McSherry.SemanticVersioning
         /// <see cref="Concise"/>.
         /// </para>
         /// </remarks>
+        [Obsolete("Use custom format strings instead.", error: false)]
         public static string PrefixedConcise    => "c";
 
         /// <summary>
@@ -91,7 +95,10 @@ namespace McSherry.SemanticVersioning
         /// with a letter "v". Aliases <see cref="PrefixedConcise"/>.
         /// </para>
         /// </summary>
+        [Obsolete("Use custom format strings instead.", error: false)]
         public static string PrefixedMonotonic  => PrefixedConcise;
+
+#pragma warning restore 618
     }
 
     // Documentation/attributes/interfaces/etc are in the main
@@ -204,6 +211,8 @@ namespace McSherry.SemanticVersioning
                 //              for [ToString(string, IFormatProvider] on the
                 //              [SemanticVersion] class.
 
+#pragma warning disable 618
+
                 Fmtrs = new Dictionary<string, FmtRoutine>
                 {
                     [SVF.Default]           = Default,
@@ -212,6 +221,9 @@ namespace McSherry.SemanticVersioning
                     [SVF.Concise]           = Concise,
                     [SVF.PrefixedConcise]   = (sv) => $"v{Concise(sv)}",
                 }.AsReadOnly();
+
+#pragma warning restore 618
+
             }
 
             /// <summary>

--- a/McSherry.SemanticVersioning/SemanticVersion.Formatting.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Formatting.cs
@@ -153,21 +153,19 @@ namespace McSherry.SemanticVersioning
                     // If there are pre-release identifiers, they're next
                     if (semver.Identifiers.Count > 0)
                     {
-                        sb.Append($"-{semver.Identifiers[0]}");
+                        sb.AppendFormat("-{0}", semver.Identifiers[0]);
 
-                        semver.Identifiers
-                            .Skip(1)
-                            .Aggregate(sb, (_, i) => sb.AppendFormat(".{0}", i));
+                        for (int i = 1; i < semver.Identifiers.Count; i++)
+                            sb.AppendFormat(".{0}", semver.Identifiers[i]);
                     }
 
                     // And the same with metadata items
                     if (semver.Metadata.Count > 0)
                     {
-                        sb.Append($"+{semver.Metadata[0]}");
+                        sb.AppendFormat("+{0}", semver.Metadata[0]);
 
-                        semver.Metadata
-                            .Skip(1)
-                            .Aggregate(sb, (_, i) => sb.AppendFormat(".{0}", i));
+                        for (int i = 1; i < semver.Metadata.Count; i++)
+                            sb.AppendFormat(".{0}", semver.Metadata[i]);
                     }
 
                     return sb.ToString();

--- a/McSherry.SemanticVersioning/SemanticVersion.Formatting.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Formatting.cs
@@ -26,8 +26,6 @@ using McSherry.SemanticVersioning.Internals.Shims;
 
 namespace McSherry.SemanticVersioning
 {
-    using SVF = SemanticVersionFormat;
-
     /// <summary>
     /// <para>
     /// Lists the format identifiers accepted by the 
@@ -55,7 +53,14 @@ namespace McSherry.SemanticVersioning
         /// <remarks>
         /// <para>
         /// For details on how this option formats a semantic version,
-        /// see <see cref="Default"/>.
+        /// see <see cref="Default"/>. Standard format specifiers that include a
+        /// prefix have been deprecated in favour of using custom format patterns,
+        /// which can include any prefix desired.
+        /// </para>
+        /// <para>
+        /// See remarks for <see cref="SemanticVersion"/>'s implementation of
+        /// <see cref="IFormattable.ToString(string, IFormatProvider)"/> for
+        /// further information.
         /// </para>
         /// </remarks>
         [Obsolete("Use custom format strings instead.", error: false)]
@@ -78,7 +83,14 @@ namespace McSherry.SemanticVersioning
         /// <remarks>
         /// <para>
         /// For details on how this option formats a semantic version, see
-        /// <see cref="Concise"/>.
+        /// <see cref="Concise"/>. Standard format specifiers that include a
+        /// prefix have been deprecated in favour of using custom format patterns,
+        /// which can include any prefix desired.
+        /// </para>
+        /// <para>
+        /// See remarks for <see cref="SemanticVersion"/>'s implementation of
+        /// <see cref="IFormattable.ToString(string, IFormatProvider)"/> for
+        /// further information.
         /// </para>
         /// </remarks>
         [Obsolete("Use custom format strings instead.", error: false)]
@@ -86,17 +98,32 @@ namespace McSherry.SemanticVersioning
 
         /// <summary>
         /// <para>
-        /// The format used for monotonic version strings. Aliases
-        /// <see cref="Concise"/>.
+        /// The format used for monotonic version strings.
         /// </para>
         /// </summary>
+        /// <remarks>
+        /// This property aliases <see cref="Concise"/>.
+        /// </remarks>
+        [Obsolete("Use 'Concise' instead.", error: false)]
         public static string Monotonic          => Concise;
         /// <summary>
         /// <para>
         /// The format used for monotonic version strings, prefixed
-        /// with a letter "v". Aliases <see cref="PrefixedConcise"/>.
+        /// with a letter "v". 
         /// </para>
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This property aliases <see cref="PrefixedConcise"/>. Standard format
+        /// specifiers that include a prefix have been deprecated in favour of
+        /// using custom format patterns, which can include any prefix desired.
+        /// </para>
+        /// <para>
+        /// See remarks for <see cref="SemanticVersion"/>'s implementation of
+        /// <see cref="IFormattable.ToString(string, IFormatProvider)"/> for
+        /// further information.
+        /// </para>
+        /// </remarks>
         [Obsolete("Use custom format strings instead.", error: false)]
         public static string PrefixedMonotonic  => PrefixedConcise;
 
@@ -145,7 +172,7 @@ namespace McSherry.SemanticVersioning
                 // We'll probably be passed the general format specifier most of
                 // the time, so we can return that format without getting into
                 // parsing the format string.
-                if (String.IsNullOrEmpty(format) || format == SVF.Default)
+                if (String.IsNullOrEmpty(format) || format == SemanticVersionFormat.Default)
                 {
                     // The basics are always present
                     sb.AppendFormat("{0}.{1}.{2}", semver.Major, semver.Minor, semver.Patch);
@@ -525,7 +552,7 @@ namespace McSherry.SemanticVersioning
         /// </para>
         /// </summary>
         /// <param name="format">
-        /// The format to use, or null for the default format.
+        /// The format pattern to use, or null for the general format.
         /// </param>
         /// <param name="provider">
         /// The format provider to use, or null for the default provider. 
@@ -536,86 +563,9 @@ namespace McSherry.SemanticVersioning
         /// formatted as specified.
         /// </returns>
         /// <exception cref="FormatException">
-        /// Thrown when the format specifier given in <paramref name="format"/>
+        /// Thrown when the format pattern given in <paramref name="format"/>
         /// is not recognised or is invalid.
         /// </exception>
-        /// <remarks>
-        /// <para>
-        /// The format of a Semantic Version is not dependent on culture
-        /// information, and so the value of <paramref name="provider"/>
-        /// is ignored.
-        /// </para>
-        /// <para>
-        /// The value of <paramref name="format"/> should contain one of
-        /// the below-listed format specifiers. Custom format patterns
-        /// are not supported. If <paramref name="format"/> is null, the
-        /// default format specifier, "G", is used in its place.
-        /// </para>
-        /// <para>
-        /// The list of recognised format specifiers is given in the
-        /// below table.
-        /// </para>
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Format Specifier</term>
-        ///         <term>Description</term>
-        ///         <term>Example</term>
-        ///     </listheader>
-        /// 
-        ///     <item>
-        ///         <term><c>"c"</c></term>
-        ///         <term>
-        ///             Prefixed concise format. Identical
-        ///             to the concise format (<c>"C"</c>),
-        ///             except prefixed with a lowercase "v".
-        ///         </term>
-        ///         <term>
-        ///             <para>v1.8</para>
-        ///             <para>v1.15.1</para>
-        ///             <para>v2.1-beta.3</para>
-        ///         </term>
-        ///     </item>
-        ///     <item>
-        ///         <term><c>"C"</c></term>
-        ///         <term>
-        ///             Concise format. Omits metadata items,
-        ///             and only includes the <see cref="Patch"/>
-        ///             version if it is non-zero.
-        ///         </term>
-        ///         <term>
-        ///             <para>1.8</para>
-        ///             <para>1.15.1</para>
-        ///             <para>2.1-beta.3</para>
-        ///         </term>
-        ///     </item>
-        /// 
-        ///     <item>
-        ///         <term><c>"g"</c></term>
-        ///         <term>
-        ///             Prefixed default format. Identical to
-        ///             the default format (<c>"G"</c>), except
-        ///             prefixed with a lowercase "v".
-        ///         </term>
-        ///         <term>
-        ///             <para>v1.7.0-alpha.2+20150925.f8f2cb1a</para>
-        ///             <para>v1.2.5</para>
-        ///             <para>v2.0.1-rc.1</para>
-        ///         </term>
-        ///     </item>
-        ///     <item>
-        ///         <term><c>"G"</c>, <c>null</c></term>
-        ///         <term>
-        ///             The default format, as given by the
-        ///             Semantic Versioning 2.0.0 specification.
-        ///         </term>
-        ///         <term>
-        ///             <para>1.7.0-alpha.2+20150925.f8f2cb1a</para>
-        ///             <para>1.2.5</para>
-        ///             <para>2.0.1-rc.1</para>
-        ///         </term>
-        ///     </item>
-        /// </list>
-        /// </remarks>
         string IFormattable.ToString(string format, IFormatProvider provider)
         {
             return Formatter.Format(this, format);
@@ -627,14 +577,14 @@ namespace McSherry.SemanticVersioning
         /// </para>
         /// </summary>
         /// <param name="format">
-        /// The format to use, or null for the default format.
+        /// The format pattern to use, or null for the general format.
         /// </param>
         /// <returns>
         /// A string representation of the current <see cref="SemanticVersion"/>,
         /// formatted as specified.
         /// </returns>
         /// <exception cref="FormatException">
-        /// Thrown when the format specifier given in <paramref name="format"/>
+        /// Thrown when the format pattern given in <paramref name="format"/>
         /// is not recognised or is invalid.
         /// </exception>
         /// <remarks>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,4 +45,4 @@ test_script:
 # Only parsing benchmarks are run as they can complete relatively quickly. Others
 # can be run as and when required as they take significantly longer.
 after_test:
-    - ps: dotnet benchmark .\McSherry.SemanticVersioning.Benchmarking\bin\Release\netcoreapp2.1\McSherry.SemanticVersioning.Benchmarking.dll --filter *ParsingBenchmarks.*
+    - ps: dotnet benchmark .\McSherry.SemanticVersioning.Benchmarking\bin\Release\netcoreapp2.1\McSherry.SemanticVersioning.Benchmarking.dll --filter *ParsingBenchmarks.* SemanticVersionFormatBenchmarks

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ branches:
         - master
         - stable
 
-pull_requests.do_not_increment_build_number: true
+pull_requests:
+    do_not_increment_build_number: true
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,14 @@ image: Visual Studio 2019
 
 configuration: Release
 
+branches:
+    only:
+        - master
+        - stable
+
+pull_requests.do_not_increment_build_number: true
+
+
 install:
     - ps: dotnet tool install -g BenchmarkDotNet.Tool
 

--- a/docs/McSherry.SemanticVersioning/SemanticVersion/IFormattable.ToString(String,IFormatProvider).md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersion/IFormattable.ToString(String,IFormatProvider).md
@@ -47,34 +47,40 @@ formatted as specified.
   
 ## Remarks
 
-The format of a Semantic Version is not dependent on culture
-information, and so the value of _`provider`_ is ignored.
+The format of a Semantic Version is not dependent on culture information, and so the value of _`provider`_ is ignored.
 
-The value of _`format`_ should contain one of the below-listed
-format specifiers. Custom format patterns are not supported. If
-_`format`_ is null, the default format specifier, `G`, is used
-in its place.
+The parameter _`format`_ should be a string containing a custom format pattern as set out below. If it is `null` or an empty string, the general format specifier `G` is used. In _`format`_, any character which is not a format specifier (including whitespace) is included verbatim in the resulting formatted string.
 
-The list of recognised format specifiers is given in the below.
+The formatter will ignore any characters placed between double braces. For example, `G` will be interpreted as the general format specifier while `{{G}}` will be included as the literal character "G".
 
-- **`c`**  
-  **Description:** Prefixed concise format. Identical to the
-  concise format (`C`), except prefixed with a lowercase `v`.  
-  **Examples:** `v1.8`, `v1.15.1`, `v2.1-beta.3`
-  
-- **`C`**  
-  **Description:** Concise format. Omits metadata items, and only
-  includes the [Patch][3] version if it is non-zero.
-  **Examples:** `1.8`, `1.15.1`, `2.1-beta.3`
-  
-- **`g`**  
-  **Description:** Prefixed default format. Identical to the
-  default format (`G`), except prefixed with a lowercase `v`.
-  **Examples:** `v1.7.0-alpha.2+20150925.f8f2cb1a`, `v1.2.5`,
-  `v2.0.1-rc.1`
-  
-- **`G`**  
-  **Description:** The default format, as given by the Semantic
-  Versioning 2.0.0 specification.  
-  **Examples:** `1.7.0-alpha.2+20150925.f8f2cb1a`, `1.2.5`,
-  `2.0.1-rc.1`
+### Standard format specifiers
+
+The following single-character standard format specifiers can be used as shorthand for longer custom format patterns. In formatting a Semantic Version, they are expanded in place to the custom format patterns given in the table.
+
+| Specifier | Expansion  | Description                                                  | Example                            |
+| --------- | ---------- | ------------------------------------------------------------ | ---------------------------------- |
+| `G`       | `M.m.pRD`  | The general format specifier. Includes all version components and, if present, all pre-release identifiers and metadata items. | `1.7.0-alpha.2+20150925.f8f2cb1a`  |
+| `g`       | `vM.m.pRD` | (Deprecated) The prefixed general format specifier. Identical to the general format specifier, except prefixed with `v`. | `v1.7.0-alpha.2+20150925.f8f2cb1a` |
+| `C`       | `M.mppR`   | The concise format specifier. Only includes the patch component if it is non-zero and never includes metadata items. | `1.7-alpha.2`, `2.0.3-rc.1`        |
+| `c`       | `vM.mppR`  | (Deprecated) The prefixed concise format specifier. Identical to the concise format specifier, except prefixed with `v`. | `v1.7-alpha.2`, `v2.0.3-rc.1`      |
+
+### Custom format specifiers
+
+The custom format specifiers shown in the table below allow inserting individual parts of a Semantic Version into the string.
+
+| Format specifier | Description                                                  | Example                |
+| ---------------- | ------------------------------------------------------------ | ---------------------- |
+| `M`              | Major version. Includes the major version component.         | `1`                    |
+| `m`              | Minor version. Includes the minor version component.         | `7`                    |
+| `p`              | Patch version. Includes the patch version component.         | `0`                    |
+| `pp`             | Optional patch version. Includes the patch version component with a separator character only if the component is non-zero. Otherwise includes nothing. | `.3`                   |
+| `R`              | Prefixed pre-release identifier group. If the version has pre-release identifiers, includes all identifiers prefixed with a hyphen and with separator characters. Otherwise includes nothing. | `-alpha.2`             |
+| `r`              | Standalone pre-release identifier group. If the version has pre-release identifiers, includes all identifiers with separator characters. Otherwise includes nothing. | `alpha.2`              |
+| `r0`, `r1`       | Indexed pre-release identifier. Includes the pre-release identifier with the specified zero-based index. An out-of-bounds index produces an error. | `alpha`, `2`           |
+| `rr`             | Reserved. Use produces an error.                             | N/A                    |
+| `D`              | Prefixed metadata item group. If the version has metadata items, includes all items prefixed with a plus sign and with separator characters. Otherwise includes nothing. | `+20150925.f8f2cb1a`   |
+| `d`              | Standalone metadata item group. If the version has metadata items, includes all items with separator characters. Otherwise includes nothing. | `20150925.f8f2cb1a`    |
+| `d0`, `d1`       | Indexed metadata item. Includes the metadata item with the specified zero-based index. An out-of-bounds index produces an error. | `20150925`, `f8f2cb1a` |
+| `dd`             | Reserved. Use produces an error.                             | N/A                    |
+
+In future, new meaning may be given to repetitions or different cases of the specifiers given above (such as `RR`,  `P`, or `PP`). These specifiers should not be used but will not produce an error.

--- a/docs/McSherry.SemanticVersioning/SemanticVersion/IFormattable.ToString(String,IFormatProvider).md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersion/IFormattable.ToString(String,IFormatProvider).md
@@ -57,12 +57,12 @@ The formatter will ignore any characters placed between double braces. For examp
 
 The following single-character standard format specifiers can be used as shorthand for longer custom format patterns. In formatting a Semantic Version, they are expanded in place to the custom format patterns given in the table.
 
-| Specifier | Expansion  | Description                                                  | Example                            |
-| --------- | ---------- | ------------------------------------------------------------ | ---------------------------------- |
-| `G`       | `M.m.pRD`  | The general format specifier. Includes all version components and, if present, all pre-release identifiers and metadata items. | `1.7.0-alpha.2+20150925.f8f2cb1a`  |
-| `g`       | `vM.m.pRD` | (Deprecated) The prefixed general format specifier. Identical to the general format specifier, except prefixed with `v`. | `v1.7.0-alpha.2+20150925.f8f2cb1a` |
-| `C`       | `M.mppR`   | The concise format specifier. Only includes the patch component if it is non-zero and never includes metadata items. | `1.7-alpha.2`, `2.0.3-rc.1`        |
-| `c`       | `vM.mppR`  | (Deprecated) The prefixed concise format specifier. Identical to the concise format specifier, except prefixed with `v`. | `v1.7-alpha.2`, `v2.0.3-rc.1`      |
+| Specifier | Expansion    | Description                                                  | Example                            |
+| --------- | ------------ | ------------------------------------------------------------ | ---------------------------------- |
+| `G`       | `M.m.pRRDD`  | The general format specifier. Includes all version components and, if present, all pre-release identifiers and metadata items. | `1.7.0-alpha.2+20150925.f8f2cb1a`  |
+| `g`       | `vM.m.pRRDD` | (Deprecated) The prefixed general format specifier. Identical to the general format specifier, except prefixed with `v`. | `v1.7.0-alpha.2+20150925.f8f2cb1a` |
+| `C`       | `M.mppRR`    | The concise format specifier. Only includes the patch component if it is non-zero and never includes metadata items. | `1.7-alpha.2`, `2.0.3-rc.1`        |
+| `c`       | `vM.mppRR`   | (Deprecated) The prefixed concise format specifier. Identical to the concise format specifier, except prefixed with `v`. | `v1.7-alpha.2`, `v2.0.3-rc.1`      |
 
 ### Custom format specifiers
 
@@ -74,13 +74,13 @@ The custom format specifiers shown in the table below allow inserting individual
 | `m`              | Minor version. Includes the minor version component.         | `7`                    |
 | `p`              | Patch version. Includes the patch version component.         | `0`                    |
 | `pp`             | Optional patch version. Includes the patch version component with a separator character only if the component is non-zero. Otherwise includes nothing. | `.3`                   |
-| `R`              | Prefixed pre-release identifier group. If the version has pre-release identifiers, includes all identifiers prefixed with a hyphen and with separator characters. Otherwise includes nothing. | `-alpha.2`             |
-| `r`              | Standalone pre-release identifier group. If the version has pre-release identifiers, includes all identifiers with separator characters. Otherwise includes nothing. | `alpha.2`              |
+| `R`              | Standalone optional pre-release identifier group. If the version has pre-release identifiers, includes all identifiers with separator characters. Otherwise includes nothing. | `alpha.2`              |
+| `RR`             | Prefixed optional pre-release identifier group. If the version has pre-release identifiers, includes all identifiers prefixed with a hyphen and with separator characters. Otherwise includes nothing. | `-alpha.2`             |
 | `r0`, `r1`       | Indexed pre-release identifier. Includes the pre-release identifier with the specified zero-based index. An out-of-bounds index produces an error. | `alpha`, `2`           |
 | `rr`             | Reserved. Use produces an error.                             | N/A                    |
-| `D`              | Prefixed metadata item group. If the version has metadata items, includes all items prefixed with a plus sign and with separator characters. Otherwise includes nothing. | `+20150925.f8f2cb1a`   |
-| `d`              | Standalone metadata item group. If the version has metadata items, includes all items with separator characters. Otherwise includes nothing. | `20150925.f8f2cb1a`    |
+| `D`              | Standalone optional metadata item group. If the version has metadata items, includes all items with separator characters. Otherwise includes nothing. | `20150925.f8f2cb1a`    |
+| `DD`             | Prefixed optional metadata item group. If the version has metadata items, includes all items prefixed with a plus sign and with separator characters. Otherwise includes nothing. | `+20150925.f8f2cb1a`   |
 | `d0`, `d1`       | Indexed metadata item. Includes the metadata item with the specified zero-based index. An out-of-bounds index produces an error. | `20150925`, `f8f2cb1a` |
 | `dd`             | Reserved. Use produces an error.                             | N/A                    |
 
-In future, new meaning may be given to repetitions or different cases of the specifiers given above (such as `RR`,  `P`, or `PP`). These specifiers should not be used but will not produce an error.
+In future, new meaning may be given to repetitions or different cases of the specifiers given above (such as `r`,  `P`, or `PP`). These specifiers should not be used but will not produce an error.

--- a/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedConcise.md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedConcise.md
@@ -1,6 +1,7 @@
 # `SemanticVersionFormat.PrefixedConcise` property
 
 ```c#
+[Obsolete]
 public static string PrefixedConcise => "c"
 ```
 
@@ -19,4 +20,7 @@ letter `v`.
 For details on how this option formats a semantic version, see
 [Concise][2].
 
+This format specifier is deprecated in favour of custom format strings. See [SemanticVersion.ToString][3] for further information.
+
 [2]: ./Concise.md
+[3]: ../SemanticVersion/IFormattable.ToString(String,IFormatProvider).md

--- a/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedConcise.md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedConcise.md
@@ -17,10 +17,10 @@ letter `v`.
 
 ## Remarks
 
-For details on how this option formats a semantic version, see
-[Concise][2].
+For details on how this option formats a semantic version, see [Concise][2]. Standard format specifiers that include a prefix have been deprecated in favour of using custom format patterns, which can include any prefix desired.
 
-This format specifier is deprecated in favour of custom format strings. See [SemanticVersion.ToString][3] for further information.
+See remarks for [SemanticVersion][1a]'s implementation of [IFormattable.ToString][3] for further information.
 
+[1a]: ../
 [2]: ./Concise.md
 [3]: ../SemanticVersion/IFormattable.ToString(String,IFormatProvider).md

--- a/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedDefault.md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedDefault.md
@@ -17,10 +17,10 @@ a letter `v`.
 
 ## Remarks
 
-For details on how this option formats a semantic version, see
-[Default][2].
+For details on how this option formats a semantic version, see [Default][2]. Standard format specifiers that include a prefix have been deprecated in favour of using custom format patterns, which can include any prefix desired.
 
-This format specifier is deprecated in favour of custom format strings. See [SemanticVersion.ToString][3] for further information.
+See remarks for [SemanticVersion][1a]'s implementation of [IFormattable.ToString][3] for further information.
 
+[1a]: ../
 [2]: ./Default.md
 [3]: ../SemanticVersion/IFormattable.ToString(String,IFormatProvider).md

--- a/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedDefault.md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersionFormat/PrefixedDefault.md
@@ -1,6 +1,7 @@
 # `SemanticVersionFormat.PrefixedDefault` property
 
 ```c#
+[Obsolete]
 public static string PrefixedDefault => "g"
 ```
 
@@ -19,4 +20,7 @@ a letter `v`.
 For details on how this option formats a semantic version, see
 [Default][2].
 
+This format specifier is deprecated in favour of custom format strings. See [SemanticVersion.ToString][3] for further information.
+
 [2]: ./Default.md
+[3]: ../SemanticVersion/IFormattable.ToString(String,IFormatProvider).md

--- a/docs/McSherry.SemanticVersioning/SemanticVersionFormat/README.md
+++ b/docs/McSherry.SemanticVersioning/SemanticVersionFormat/README.md
@@ -20,13 +20,13 @@ class's implementation of `IFormattable`.
 
 - **[Default][3]**  
   The default way to format a semantic version.
-- **[PrefixedDefault][4]**  
+- (Deprecated) **[PrefixedDefault][4]**  
   The default way to format a semantic version, prefixed with a
   letter `v`.
 - **[Concise][5]**  
   A way to concisely format a semantic version. Omits metadata and
   only includes the [Patch][6] version if it is non-zero.
-- **[PrefixedConcise][7]**  
+- (Deprecated) **[PrefixedConcise][7]**  
   A concise way to format a semantic version, prefixed with a
   letter `v`.
   


### PR DESCRIPTION
This pull request will close #15.

Formatting `SemanticVersion` objects in v1.3.0 and before isn't a great experience unless all you need is one of the pre-provided formats. Compared with `DateTime` and other .NET objects, which support rich free-form custom format patterns, it is a very poor experience.

Support for custom format patterns in a similar style would be a good improvement. As of drafting this pull request, an [explanatory specification][1] is available.

For an example of the improvement, assume a user includes the built commit as the first metadata item with the version number, and wants to display it as `1.2.3 (c666efc)`. Provided below are two examples of how this would be done, with and without custom format patterns.

**Without:**

```c#
$"{v.Major}.{v.Minor}.{v.Patch} ({v.Metadata[0]})"
```

**With custom format patterns:**

```c#
$"{v:M.m.p (d0)}"
```

If requirements are more complex than this, the difference will be even more pronounced.

[1]: https://github.com/McSherry/McSherry.SemanticVersioning/blob/304ce986a66ef786ed52d4afc4d5dae8891bd47a/docs/McSherry.SemanticVersioning/SemanticVersion/IFormattable.ToString(String%2CIFormatProvider).md