### PR TITLE
Add 'node-semver' version range comparison functions

### DIFF
--- a/McSherry.SemanticVersioning/Ranges/VersionRange.Comparison.cs
+++ b/McSherry.SemanticVersioning/Ranges/VersionRange.Comparison.cs
@@ -35,29 +35,6 @@ namespace McSherry.SemanticVersioning.Ranges
         /// </summary>
         internal interface IComparator
         {
-            /*
-                So, why bother with this interface if it's private and
-                we've only got one class implementing it, and that class
-                is little more than a shell?
-
-                Answer: future proofing.
-
-                Currently, we only support the basic features of version
-                ranges specified by the 'node-semver' docs, but in future
-                we're likely to support the advanced features, and the
-                advanced features all decompose into a set of the basic
-                features.
-
-                By having this interface here from the start, we don't need
-                to do a large amount of rework, we just need to make the
-                [VersionRange] class implement the interface, we need to 
-                add the appropriate [Operator] values for the advanced features,
-                and we then make [Comparator.Create] return [VersionRange]s
-                for advanced features, and that's that. It'll also be entirely
-                transparent to the [VersionRange] consuming it, which is a big
-                plus.
-            */
-
             /// <summary>
             /// <para>
             /// Determines whether the comparator is satisfied

--- a/McSherry.SemanticVersioning/Ranges/VersionRange.cs
+++ b/McSherry.SemanticVersioning/Ranges/VersionRange.cs
@@ -20,7 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Runtime.CompilerServices;
 using McSherry.SemanticVersioning.Internals.Shims;
 
 namespace McSherry.SemanticVersioning.Ranges
@@ -76,7 +76,7 @@ namespace McSherry.SemanticVersioning.Ranges
     [Serializable]
     [CLSCompliant(true)]
     public sealed partial class VersionRange
-        : VersionRange.IComparator
+        : VersionRange.IComparator, IComparable<SemanticVersion>
     {
         // Used as a passthrough method so that the constructor taking a string
         // argument can use constructor chaining to avoid duplicate code.
@@ -298,6 +298,34 @@ namespace McSherry.SemanticVersioning.Ranges
         public bool SatisfiedBy(IEnumerable<SemanticVersion> semvers)
         {
             return semvers.All(this.SatisfiedBy);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="SemanticVersion"/> is
+        /// outside the bounds of the current version range.
+        /// </summary>
+        /// <param name="semver">
+        /// The <see cref="SemanticVersion"/> to compare to the current version
+        /// range.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// If <paramref name="semver"/> has higher precedence than all versions
+        /// that satisfy the current version range, an integer greater than zero.
+        /// </para>
+        /// <para>
+        /// If <paramref name="semver"/> has lower precedence than all versions
+        /// that satisfy the current version range, an integer less than zero.
+        /// </para>
+        /// <para>
+        /// If <paramref name="semver"/> satisfies the current version range, if it
+        /// is neither greater than nor less than all versions that satisfy the
+        /// current version range, or if it is <see langword="null"/>, zero.
+        /// </para>
+        /// </returns>
+        public int CompareTo(SemanticVersion semver)
+        {
+            throw new NotImplementedException();
         }
 
         bool IComparator.ComparableTo(SemanticVersion comparand)

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/CompareTo(SemanticVersion).md.md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/CompareTo(SemanticVersion).md.md
@@ -1,0 +1,34 @@
+# `VersionRange.CompareTo(SemanticVersion)` method
+
+```c#
+public int CompareTo(
+    SemanticVersion semver
+    )
+```
+
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
+**Minimum version:** 1.4.0
+**Implements:** `System.IComparable<SemanticVersion>.CompareTo`
+
+[1]: ../
+
+Determines whether the specified [SemanticVersion][2] is outside the bounds of the current version range.
+
+[2]: ../SemanticVersion
+
+
+### Parameters
+
+- **`semver`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+  The [SemanticVersion][2] to compare to the current version range.
+
+### Return Value
+
+**Type:** `System.Int32`
+
+| Return value      | Condition                                                    |
+| ----------------- | ------------------------------------------------------------ |
+| Greater than zero | When _`semver`_ has higher precedence than all versions that satisfy the current version range. |
+| Zero              | When _`semver`_ satisfies the current version range, is neither greater than nor less than all versions that satisfy the current version range, or is `null`. |
+| Less than zero    | When _`semver`_ has lower precedence than all versions that satisfy the current version range. |

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
@@ -3,7 +3,7 @@
 ```c#
 [Serializable]
 [CLSCompliant(true)]
-public sealed class VersionRange
+public sealed class VersionRange : IComparable<SemanticVersion>
 ```
 
 **Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
@@ -42,10 +42,12 @@ inherited.
 - **[SatisfiedBy(SemanticVersion[])][5]**  
   Determines whether the current range is satisfied by all
   specified [SemanticVersion][4] instances.
-  
+- **[`IComparable<SemanticVersion>` CompareTo(SemanticVersion)][5A]**
+  Determines whether the specified [SemanticVersion][4] is outside the bounds of the current version range.
 [3]: ./SatisfiedBy(SemanticVersion).md
 [4]: ../SemanticVersion
 [5]: ./SatisfiedBy(SemanticVersion).md
+[5A]:./CompareTo(SemanticVersion).md
 
 
 ## Static Methods


### PR DESCRIPTION
Under `node-semver`, it's possible to compare a version range against a semantic version to determine more than just whether the version range is satisfied. Similarly, version ranges can be compared and operated on with each other. Supporting this in `McSherry.SemanticVersioning` seems beneficial as it maintains parity with `node-semver` on version ranges.

The functions are:

- [ ] `outside` / `gtr` / `ltr` &mdash; comparisons to determine whether a semantic version is outwith the range covered by the version range

- [ ] `intersects` &mdash; determines whether two version ranges overlap

- [ ] `subset` &mdash; determines whether one version range entirely includes another

Something to review in doing this will be changes to the `node-semver` version range specification. At present, we claim compatibility with v6.0.0, but `node-semver` is now on v7.3.2. Revising our claim to a later version is just good housekeeping.