### PR TITLE
Implement support for redundant wildcards

### DIFF
--- a/McSherry.SemanticVersioning.Testing/Ranges/RangeTests.cs
+++ b/McSherry.SemanticVersioning.Testing/Ranges/RangeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-19 Liam McSherry
+﻿// Copyright (c) 2015-20 Liam McSherry
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/McSherry.SemanticVersioning.Testing/Ranges/RangeTests.cs
+++ b/McSherry.SemanticVersioning.Testing/Ranges/RangeTests.cs
@@ -953,6 +953,8 @@ namespace McSherry.SemanticVersioning.Ranges
             var vr2d = new VersionRange("1.*.*");
             var vr2e = new VersionRange("1.x.x");
             var vr2f = new VersionRange("1.X.X");
+            var vr2g = new VersionRange("1.x.X");
+            var vr2h = new VersionRange("1.*.X");
 
             (string VID, SemanticVersion Version, bool Expected)[] vectors2 =
             {
@@ -987,6 +989,8 @@ namespace McSherry.SemanticVersioning.Ranges
             Test2("Asterisk, redundant", vr2d);
             Test2("Lowercase, redundant", vr2e);
             Test2("Uppercase, redundant", vr2f);
+            Test2("Mixed (xX), redundant", vr2g);
+            Test2("Mixed (*X), redundant", vr2h);
 
 
             // Tests for the case where the major version is a wildcard
@@ -1006,6 +1010,8 @@ namespace McSherry.SemanticVersioning.Ranges
                 ("Uppercase, one", new VersionRange("X")),
                 ("Asterisk, two", new VersionRange("*.*")),
                 ("Lowercase, three", new VersionRange("x.x.x")),
+                ("Mixed, two", new VersionRange("x.*")),
+                ("Mixed, three", new VersionRange("x.*.X")),
             };
 
             var rng = new Random();

--- a/McSherry.SemanticVersioning.Testing/Ranges/RangeTests.cs
+++ b/McSherry.SemanticVersioning.Testing/Ranges/RangeTests.cs
@@ -950,6 +950,9 @@ namespace McSherry.SemanticVersioning.Ranges
             var vr2a = new VersionRange("1.x");
             var vr2b = new VersionRange("1.X");
             var vr2c = new VersionRange("1.*");
+            var vr2d = new VersionRange("1.*.*");
+            var vr2e = new VersionRange("1.x.x");
+            var vr2f = new VersionRange("1.X.X");
 
             (string VID, SemanticVersion Version, bool Expected)[] vectors2 =
             {
@@ -981,6 +984,9 @@ namespace McSherry.SemanticVersioning.Ranges
             Test2("Lowercase", vr2a);
             Test2("Uppercase", vr2b);
             Test2("Asterisk", vr2c);
+            Test2("Asterisk, redundant", vr2d);
+            Test2("Lowercase, redundant", vr2e);
+            Test2("Uppercase, redundant", vr2f);
 
 
             // Tests for the case where the major version is a wildcard
@@ -992,7 +998,16 @@ namespace McSherry.SemanticVersioning.Ranges
             //
             // If something does fall over, we'll need to add a specific test
             // for it as we're not guaranteed to get the same value again.
-            var vr3 = new VersionRange("*");
+
+            var vr3 = new (string Name, VersionRange Range)[]
+            {
+                ("Asterisk, one", new VersionRange("*")),
+                ("Lowercase, one", new VersionRange("x")),
+                ("Uppercase, one", new VersionRange("X")),
+                ("Asterisk, two", new VersionRange("*.*")),
+                ("Lowercase, three", new VersionRange("x.x.x")),
+            };
+
             var rng = new Random();
 
             // Anything without pre-release identifiers should be true
@@ -1004,10 +1019,13 @@ namespace McSherry.SemanticVersioning.Ranges
                     patch: rng.Next()
                     );
 
-                Assert.IsTrue(
-                    condition:  vr3.SatisfiedBy(sv),
-                    message:    $"Failure, T3: {sv}"
-                    );
+                foreach (var vr in vr3)
+                {
+                    Assert.IsTrue(
+                        condition: vr.Range.SatisfiedBy(sv),
+                        message: $"Failure, {vr.Name}, T3: {sv}"
+                        );
+                }
             }
 
             // Anything with them should be false
@@ -1034,10 +1052,13 @@ namespace McSherry.SemanticVersioning.Ranges
                         );
                 }
 
-                Assert.IsFalse(
-                    condition:  vr3.SatisfiedBy(sv),
-                    message:    $"Failure: {sv}"
-                    );
+                foreach (var vr in vr3)
+                {
+                    Assert.IsFalse(
+                        condition: vr.Range.SatisfiedBy(sv),
+                        message: $"Failure, {vr.Name}, F3: {sv}"
+                        );
+                }
             }
 
             IEnumerable<string> GetRandomIdentifiers()

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-19 Liam McSherry
+﻿// Copyright (c) 2015-20 Liam McSherry
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
@@ -847,11 +847,6 @@ namespace McSherry.SemanticVersioning
                 ("V3.7",    "1.0.x-alpha",  wcard),
                 ("V3.8",    "1.x-beta",     wcard),
                 ("V3.9",    "x-rc",         wcard),
-
-                // And although not part of the 'node-semver' specification, it
-                // makes the most sense not to allow multiple wildcards.
-                ("V3.10",   "1.x.x",        wcard),
-                ("V3.11",   "x.x.x",        wcard),
             };
 
             foreach (var vector in vectors3)

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
@@ -799,6 +799,19 @@ namespace McSherry.SemanticVersioning
                 ("V1.13", "x",      wcard,              (wildcard, wildcard, wildcard)),
                 ("V1.14", "X",      wcard,              (wildcard, wildcard, wildcard)),
                 ("V1.15", "*",      wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.16", "x.x.x",  wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.17", "x.x",    wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.19", "*.*.*",  wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.18", "*.*",    wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.20", "X.X.X",  wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.21", "X.X",    wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.22", "x.X.*",  wcard,              (wildcard, wildcard, wildcard)),
+                ("V1.23", "7.X.X",  wcard,              (present, wildcard, wildcard)),
+                ("V1.24", "7.x.x",  wcard,              (present, wildcard, wildcard)),
+                ("V1.25", "7.*.*",  wcard,              (present, wildcard, wildcard)),
+                ("V1.26", "7.x.X",  wcard,              (present, wildcard, wildcard)),
+                ("V1.27", "7.*.X",  wcard,              (present, wildcard, wildcard)),
+                ("V1.28", "7.X.*",  wcard,              (present, wildcard, wildcard)),
             };
 
             foreach (var vector in vectors1)
@@ -841,12 +854,23 @@ namespace McSherry.SemanticVersioning
                 ("V3.4",    "1.x.0",    wcard),
                 ("V3.5",    "x.2",      wcard),
                 ("V3.6",    "x.2.3",    wcard),
+                ("V3.7",    "*.*.15",   wcard),
 
-                // Wildcards with pre-release identifiers make no logical sense,
-                // and don't appear to work in 'node-semver' anyway
-                ("V3.7",    "1.0.x-alpha",  wcard),
-                ("V3.8",    "1.x-beta",     wcard),
-                ("V3.9",    "x-rc",         wcard),
+                // Wildcards with pre-release identifiers or build metadata make
+                // no logical sense, and don't appear to work in 'node-semver' anyway
+                ("V3.8",    "1.0.x-alpha",  wcard),
+                ("V3.9",    "1.x-beta",     wcard),
+                ("V3.10",   "1.x.x-beta",   wcard),
+                ("V3.11",   "x.x.x-rc",     wcard),
+                ("V3.12",   "X.X-rc",       wcard),
+                ("V3.13",   "*-rc",         wcard),
+
+                ("V3.14",   "1.0.x+alpha",  wcard),
+                ("V3.15",   "1.x+beta",     wcard),
+                ("V3.16",   "1.x.x+beta",   wcard),
+                ("V3.17",   "x.x.x+rc",     wcard),
+                ("V3.18",   "X.X+rc",       wcard),
+                ("V3.19",   "*+rc",         wcard),
             };
 
             foreach (var vector in vectors3)

--- a/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
+++ b/McSherry.SemanticVersioning.Testing/SemanticVersionIntlParsingTests.cs
@@ -853,7 +853,7 @@ namespace McSherry.SemanticVersioning
                 ("V3.3",    "x",        ParseMode.Lenient),
                 ("V3.4",    "1.x.0",    wcard),
                 ("V3.5",    "x.2",      wcard),
-                ("V3.6",    "x.2.3",    wcard),
+                ("V3.6",    "X.2.3",    wcard),
                 ("V3.7",    "*.*.15",   wcard),
 
                 // Wildcards with pre-release identifiers or build metadata make

--- a/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
+++ b/McSherry.SemanticVersioning/SemanticVersion.Parsing.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-19 Liam McSherry
+﻿// Copyright (c) 2015-20 Liam McSherry
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request closes #20 by implementing support in `VersionRange` for range comparators with redundant wildcards, e.g. `x.x.x` or `1.x.x`.