### PR TITLE
Target and support .NET Framework v3.5

### DIFF
--- a/McSherry.SemanticVersioning/McSherry.SemanticVersioning.csproj
+++ b/McSherry.SemanticVersioning/McSherry.SemanticVersioning.csproj
@@ -18,6 +18,7 @@
         
         <!-- Build-related information -->
         <TargetFrameworks>
+            net35;
             net45;
             net46;
             netstandard1.0;


### PR DESCRIPTION
Although old at this point, .NET Framework 3.5 remains relatively common. As `McSherry.SemanticVersioning` has no dependencies, it should be relatively straightforward to add support for this version.

As of writing, compiler errors identify two issues:

- [ ] A replacement for `Lazy<T>` (added in .NET Framework 4.0) is needed;

- [ ] Replacement for read-only collection interfaces `IReadOnlyList<T>` and `IReadOnlyDictionary<TKey, TValue>` are needed, as these were introduced with .NET Framework 4.5.

These don't seem insurmountable, so targeting .NET Framework 3.5 for the next release is reasonable.